### PR TITLE
add Ec2SsmRole

### DIFF
--- a/core/.projen/deps.json
+++ b/core/.projen/deps.json
@@ -91,6 +91,11 @@
       "type": "build"
     },
     {
+      "name": "@aws-cdk/aws-iam",
+      "version": "^1",
+      "type": "peer"
+    },
+    {
       "name": "@aws-cdk/aws-s3",
       "version": "^1",
       "type": "peer"
@@ -104,6 +109,11 @@
       "name": "constructs",
       "version": "^3.2.27",
       "type": "peer"
+    },
+    {
+      "name": "@aws-cdk/aws-iam",
+      "version": "^1",
+      "type": "runtime"
     },
     {
       "name": "@aws-cdk/aws-s3",

--- a/core/.projenrc.js
+++ b/core/.projenrc.js
@@ -31,6 +31,7 @@ const project = new AwsCdkConstructLibrary({
   cdkDependencies: [
     '@aws-cdk/core',
     '@aws-cdk/aws-s3',
+    '@aws-cdk/aws-iam',
   ],
   devDeps: [
   ],

--- a/core/package.json
+++ b/core/package.json
@@ -52,11 +52,13 @@
     "typescript": "^4.3.2"
   },
   "peerDependencies": {
+    "@aws-cdk/aws-iam": "^1",
     "@aws-cdk/aws-s3": "^1",
     "@aws-cdk/core": "^1",
     "constructs": "^3.2.27"
   },
   "dependencies": {
+    "@aws-cdk/aws-iam": "^1",
     "@aws-cdk/aws-s3": "^1",
     "@aws-cdk/core": "^1"
   },

--- a/core/src/ec2-ssm-role.ts
+++ b/core/src/ec2-ssm-role.ts
@@ -1,0 +1,23 @@
+import { Role, RoleProps, ManagedPolicy } from '@aws-cdk/aws-iam';
+import { Construct } from '@aws-cdk/core';
+
+/**
+ * @summary Construct extending IAM Role with AmazonSSMManagedInstanceCore managed policy
+ */
+
+export class Ec2SsmRole extends Role {
+
+  /**
+   * Constructs a new instance of the Ec2SsmRole class.
+   * @param {Construct} scope the Scope of the CDK Construct
+   * @param {string} id the ID of the CDK Construct
+   * @param {RoleProps} props the RoleProps [properties]{@link RoleProps}
+   * @since 1.0.0
+   * @access public
+   */
+
+  constructor(scope: Construct, id: string, props: RoleProps) {
+    super(scope, id, props);
+    this.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
+  }
+}

--- a/core/test/ec2-ssm-role.test.ts
+++ b/core/test/ec2-ssm-role.test.ts
@@ -1,0 +1,17 @@
+import { Stack } from '@aws-cdk/core';
+import { Ec2SsmRole } from '../src/ec2-ssm-role';
+import { ServicePrincipal } from '@aws-cdk/aws-iam';
+import '@aws-cdk/assert/jest';
+
+test('Ec2SsmRole construct', () => {
+
+  const ec2SsmRoleStack = new Stack();
+
+  // Instantiate Ec2SsmRole Construct
+  new Ec2SsmRole(ec2SsmRoleStack, 'Ec2SsmRole', { assumedBy: new ServicePrincipal("ec2.amazonaws.com") });
+
+  // Check if the Stack has a Role
+  expect(ec2SsmRoleStack).toHaveResource('AWS::IAM::Role');
+
+  // TODO: check the role has AmazonSSMManagedInstanceCore managed policy
+});

--- a/core/test/ec2-ssm-role.test.ts
+++ b/core/test/ec2-ssm-role.test.ts
@@ -1,6 +1,6 @@
+import { ServicePrincipal } from '@aws-cdk/aws-iam';
 import { Stack } from '@aws-cdk/core';
 import { Ec2SsmRole } from '../src/ec2-ssm-role';
-import { ServicePrincipal } from '@aws-cdk/aws-iam';
 import '@aws-cdk/assert/jest';
 
 test('Ec2SsmRole construct', () => {
@@ -8,7 +8,7 @@ test('Ec2SsmRole construct', () => {
   const ec2SsmRoleStack = new Stack();
 
   // Instantiate Ec2SsmRole Construct
-  new Ec2SsmRole(ec2SsmRoleStack, 'Ec2SsmRole', { assumedBy: new ServicePrincipal("ec2.amazonaws.com") });
+  new Ec2SsmRole(ec2SsmRoleStack, 'Ec2SsmRole', { assumedBy: new ServicePrincipal('ec2.amazonaws.com') });
 
   // Check if the Stack has a Role
   expect(ec2SsmRoleStack).toHaveResource('AWS::IAM::Role');

--- a/core/yarn.lock
+++ b/core/yarn.lock
@@ -21,7 +21,7 @@
     "@aws-cdk/core" "1.107.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-iam@1.107.0":
+"@aws-cdk/aws-iam@1.107.0", "@aws-cdk/aws-iam@^1":
   version "1.107.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.107.0.tgz#7ab84fb9ab133599aaaa6f041009d4177b1c55b0"
   integrity sha512-ZSULS+IdMK82VjcxNyLATlnYN1bQVD1om8MXGYxAkFuQLb3XL+uAa7NLVeHZtEKkPYqr8BcYlCXpB1JvGImJkA==


### PR DESCRIPTION
add a new CDK Construct Ec2SsmRole which extends iam.Role to provide a Role with AmazonSSMManagedInstanceCore managed policy