### PR TITLE
Fix lambda bundling

### DIFF
--- a/core/.projen/tasks.json
+++ b/core/.projen/tasks.json
@@ -81,12 +81,6 @@
       "description": "Full release build (test+compile)",
       "steps": [
         {
-          "exec": "esbuild src/lambdas/data-generator-setup-ts/index.ts --bundle --platform=node --target=node12 --external:aws-sdk --outfile=src/lambdas/data-generator-setup-ts/.build/index.js"
-        },
-        {
-          "exec": "esbuild src/lambdas/synchronous-athena-query-ts/index.ts --bundle --platform=node --target=node12 --external:aws-sdk --outfile=src/lambdas/synchronous-athena-query-ts/.build/index.js"
-        },
-        {
           "exec": "npx projen"
         },
         {

--- a/core/.projenrc.js
+++ b/core/.projenrc.js
@@ -74,11 +74,4 @@ project.addTask('test:destroy', {
   exec: 'cdk destroy --app=./lib/integ.default.js',
 });
 
-project.buildTask.prependExec(
-  'esbuild src/lambdas/synchronous-athena-query-ts/index.ts --bundle --platform=node --target=node12 --external:aws-sdk --outfile=src/lambdas/synchronous-athena-query-ts/.build/index.js',
-);
-project.buildTask.prependExec(
-  'esbuild src/lambdas/data-generator-setup-ts/index.ts --bundle --platform=node --target=node12 --external:aws-sdk --outfile=src/lambdas/data-generator-setup-ts/.build/index.js',
-);
-
 project.synth();

--- a/core/src/data-generator.ts
+++ b/core/src/data-generator.ts
@@ -265,7 +265,7 @@ export class DataGenerator extends Construct {
     // AWS Lambda function to prepare data generation
     const querySetupFn = new Function(this, 'querySetupFn', {
       runtime: Runtime.NODEJS_12_X,
-      code: Code.fromAsset(path.join(__dirname, 'lambdas/data-generator-setup-ts/.build')),
+      code: Code.fromAsset(path.join(__dirname, 'lambdas/data-generator-setup-ts')),
       handler: 'index.handler',
       logRetention: RetentionDays.ONE_DAY,
       timeout: Duration.seconds(30),

--- a/core/src/synchronous-athena-query.ts
+++ b/core/src/synchronous-athena-query.ts
@@ -55,7 +55,7 @@ export class SynchronousAthenaQuery extends Construct {
     // AWS Lambda function for the AWS CDK Custom Resource responsible to start query
     const athenaQueryStartFn = new Function(this, 'athenaQueryStartFn', {
       runtime: Runtime.NODEJS_12_X,
-      code: Code.fromAsset(path.join(__dirname, 'lambdas/synchronous-athena-query-ts/.build')),
+      code: Code.fromAsset(path.join(__dirname, 'lambdas/synchronous-athena-query-ts/')),
       handler: 'index.onEvent',
       logRetention: RetentionDays.ONE_DAY,
       timeout: Duration.seconds(20),
@@ -121,7 +121,7 @@ export class SynchronousAthenaQuery extends Construct {
     // AWS Lambda function for the AWS CDK Custom Resource responsible to wait for query completion
     const athenaQueryWaitFn = new Function(this, 'athenaQueryStartWaitFn', {
       runtime: Runtime.NODEJS_12_X,
-      code: Code.fromAsset(path.join(__dirname, 'lambdas/synchronous-athena-query-ts/.build')),
+      code: Code.fromAsset(path.join(__dirname, 'lambdas/synchronous-athena-query-ts')),
       handler: 'index.isComplete',
       logRetention: RetentionDays.ONE_DAY,
       timeout: Duration.seconds(20),


### PR DESCRIPTION
Since there is no dependency yet in those lambda, there is no need for esbuild and we can let projen build the js as well as packaging it automatically.

### Tests 

tested using https://github.com/flochaz/test-aws-analytics-reference-architecture 
```
npm install && npm run cdk synth
```

Description of changes:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.