### PR TITLE
feat: add data lake catalog construct

### DIFF
--- a/core/API.md
+++ b/core/API.md
@@ -78,6 +78,63 @@ AWS Glue Database name used by the DataGenerator.
 
 ---
 
+### DataLakeCatalog <a name="aws-analytics-reference-architecture.DataLakeCatalog"></a>
+
+A Data Lake Catalog composed of 3 AWS Glue Database configured with AWS best practices:   Databases for Raw/Cleaned/Transformed data,.
+
+#### Initializer <a name="aws-analytics-reference-architecture.DataLakeCatalog.Initializer"></a>
+
+```typescript
+import { DataLakeCatalog } from 'aws-analytics-reference-architecture'
+
+new DataLakeCatalog(scope: Construct, id: string)
+```
+
+##### `scope`<sup>Required</sup> <a name="aws-analytics-reference-architecture.DataLakeCatalog.parameter.scope"></a>
+
+- *Type:* [`@aws-cdk/core.Construct`](#@aws-cdk/core.Construct)
+
+the Scope of the CDK Construct.
+
+---
+
+##### `id`<sup>Required</sup> <a name="aws-analytics-reference-architecture.DataLakeCatalog.parameter.id"></a>
+
+- *Type:* `string`
+
+the ID of the CDK Construct.
+
+---
+
+
+
+#### Properties <a name="Properties"></a>
+
+##### `cleanDatabase`<sup>Required</sup> <a name="aws-analytics-reference-architecture.DataLakeCatalog.property.cleanDatabase"></a>
+
+- *Type:* [`@aws-cdk/aws-glue.Database`](#@aws-cdk/aws-glue.Database)
+
+AWS Glue Database for Clean data.
+
+---
+
+##### `rawDatabase`<sup>Required</sup> <a name="aws-analytics-reference-architecture.DataLakeCatalog.property.rawDatabase"></a>
+
+- *Type:* [`@aws-cdk/aws-glue.Database`](#@aws-cdk/aws-glue.Database)
+
+AWS Glue Database for Raw data.
+
+---
+
+##### `transformDatabase`<sup>Required</sup> <a name="aws-analytics-reference-architecture.DataLakeCatalog.property.transformDatabase"></a>
+
+- *Type:* [`@aws-cdk/aws-glue.Database`](#@aws-cdk/aws-glue.Database)
+
+AWS Glue Database for Transform data.
+
+---
+
+
 ### DataLakeStorage <a name="aws-analytics-reference-architecture.DataLakeStorage"></a>
 
 A Data Lake Storage composed of 3 Amazon S3 Buckets configured with AWS best practices:   S3 buckets for Raw/Cleaned/Transformed data,   data lifecycle optimization/transitioning to different Amazon S3 storage classes   server side buckets encryption managed by KMS.

--- a/core/src/data-lake-catalog.ts
+++ b/core/src/data-lake-catalog.ts
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { Database } from '@aws-cdk/aws-glue';
+import { Construct } from '@aws-cdk/core';
+
+
+/**
+ * A Data Lake Catalog composed of 3 AWS Glue Database configured with AWS best practices:
+ *  Databases for Raw/Cleaned/Transformed data,
+ */
+
+export class DataLakeCatalog extends Construct {
+
+  /**
+     * AWS Glue Database for Raw data
+     */
+  public readonly rawDatabase: Database;
+  /**
+     * AWS Glue Database for Clean data
+     */
+  public readonly cleanDatabase: Database;
+  /**
+     * AWS Glue Database for Transform data
+     */
+  public readonly transformDatabase: Database;
+
+  /**
+     * Construct a new instance of DataLakeCatalog based on S3 buckets with best practices configuration
+     * @param {Construct} scope the Scope of the CDK Construct
+     * @param {string} id the ID of the CDK Construct
+     * @access public
+     */
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    this.rawDatabase = new Database(this, 'raw-database', {
+      databaseName: 'ara-raw',
+    });
+
+    this.cleanDatabase = new Database(this, 'clean-database', {
+      databaseName: 'ara-clean',
+    });
+
+    this.transformDatabase = new Database(this, 'transform-database', {
+      databaseName: 'ara-transform',
+    });
+  }
+}

--- a/core/src/data-lake-storage.ts
+++ b/core/src/data-lake-storage.ts
@@ -61,7 +61,7 @@ export class DataLakeStorage extends Construct {
   public readonly transformBucket: Bucket;
 
   /**
-     * Construct a new instance of DataLakeStorage based on S3 buckets with best practices configuration
+     * Construct a new instance of DataLakeStorage based on Amazon S3 buckets with best practices configuration
      * @param {Construct} scope the Scope of the CDK Construct
      * @param {string} id the ID of the CDK Construct
      * @param {DataLakeStorageProps} props the DataLakeStorageProps properties

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -9,3 +9,4 @@ export { DataGeneratorProps, DataGenerator } from './data-generator';
 export { SynchronousAthenaQueryProps, SynchronousAthenaQuery } from './synchronous-athena-query';
 export { SingletonBucket } from './singleton-bucket';
 export { Ec2SsmRole } from './ec2-ssm-role';
+export { DataLakeCatalog } from './data-lake-catalog';

--- a/core/src/integ.default.ts
+++ b/core/src/integ.default.ts
@@ -2,15 +2,8 @@
 // SPDX-License-Identifier: MIT-0
 
 import { App, Stack } from '@aws-cdk/core';
-import { DataLakeStorage } from '.';
-import { DataGenerator } from './data-generator';
-import { Dataset } from './dataset';
+import { DataLakeCatalog } from '.';
 
 const mockApp = new App();
 const stack = new Stack(mockApp, 'teststack');
-const lake = new DataLakeStorage(stack, 'testlake', {});
-new DataGenerator(stack, 'testing-generator', {
-  sinkArn: lake.rawBucket.bucketArn,
-  dataset: Dataset.RETAIL_1GB_STORE_SALE,
-  frequency: 4,
-});
+new DataLakeCatalog(stack, 'testlake');

--- a/core/test/data-lake-catalog.test.ts
+++ b/core/test/data-lake-catalog.test.ts
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { Stack } from '@aws-cdk/core';
+import { DataLakeCatalog } from '../src/data-lake-catalog';
+import '@aws-cdk/assert/jest';
+
+test('DataLakeCatalog', () => {
+  const dataLakeCatalogStack = new Stack();
+
+  // Instantiate DataLakeCatalog Construct
+  new DataLakeCatalog(dataLakeCatalogStack, 'dataLakeCatalog');
+
+  // Test if the Stack contains 3 AWS Glue Database
+  expect(dataLakeCatalogStack).toCountResources('AWS::Glue::Database', 3);
+
+  // Test if the Databases names are expected
+  expect(dataLakeCatalogStack).toHaveResource('AWS::Glue::Database', {
+    DatabaseInput: {
+      Name: 'ara-raw',
+    },
+  });
+
+  // Test if the Databases names are expected
+  expect(dataLakeCatalogStack).toHaveResource('AWS::Glue::Database', {
+    DatabaseInput: {
+      Name: 'ara-clean',
+    },
+  });
+
+  // Test if the Databases names are expected
+  expect(dataLakeCatalogStack).toHaveResource('AWS::Glue::Database', {
+    DatabaseInput: {
+      Name: 'ara-transform',
+    },
+  });
+});


### PR DESCRIPTION
Issue #, if available:

Description of changes: add a DataLakeCatalog Construct with AWS Glue Database for Raw, Clean and Transform layers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.