### PR TITLE
fix: change names for data lake storage buckets and data lake catalog…

### DIFF
--- a/core/src/data-lake-catalog.ts
+++ b/core/src/data-lake-catalog.ts
@@ -36,15 +36,15 @@ export class DataLakeCatalog extends Construct {
     super(scope, id);
 
     this.rawDatabase = new Database(this, 'raw-database', {
-      databaseName: 'ara-raw',
+      databaseName: 'ara_raw',
     });
 
     this.cleanDatabase = new Database(this, 'clean-database', {
-      databaseName: 'ara-clean',
+      databaseName: 'ara_clean',
     });
 
     this.transformDatabase = new Database(this, 'transform-database', {
-      databaseName: 'ara-transform',
+      databaseName: 'ara_transform',
     });
   }
 }

--- a/core/src/data-lake-storage.ts
+++ b/core/src/data-lake-storage.ts
@@ -85,7 +85,7 @@ export class DataLakeStorage extends Construct {
 
     // Create the raw data bucket with the raw transitions
     this.rawBucket = new Bucket(this, 'RawBucket', {
-      bucketName: 'ara-raw' + Aws.ACCOUNT_ID,
+      bucketName: 'ara-raw-' + Aws.ACCOUNT_ID,
       encryption: BucketEncryption.KMS_MANAGED,
       enforceSSL: true,
       removalPolicy: RemovalPolicy.DESTROY,
@@ -115,7 +115,7 @@ export class DataLakeStorage extends Construct {
 
     // Create the clean data bucket
     this.cleanBucket = new Bucket(this, 'CleanBucket', {
-      bucketName: 'ara-clean' + Aws.ACCOUNT_ID,
+      bucketName: 'ara-clean-' + Aws.ACCOUNT_ID,
       encryption: BucketEncryption.KMS_MANAGED,
       enforceSSL: true,
       removalPolicy: RemovalPolicy.DESTROY,
@@ -145,7 +145,7 @@ export class DataLakeStorage extends Construct {
 
     // Create the transform data bucket
     this.transformBucket = new Bucket(this, 'TransformBucket', {
-      bucketName: 'ara-transform' + Aws.ACCOUNT_ID,
+      bucketName: 'ara-transform-' + Aws.ACCOUNT_ID,
       encryption: BucketEncryption.KMS_MANAGED,
       enforceSSL: true,
       removalPolicy: RemovalPolicy.DESTROY,

--- a/core/test/data-lake-catalog.test.ts
+++ b/core/test/data-lake-catalog.test.ts
@@ -17,21 +17,21 @@ test('DataLakeCatalog', () => {
   // Test if the Databases names are expected
   expect(dataLakeCatalogStack).toHaveResource('AWS::Glue::Database', {
     DatabaseInput: {
-      Name: 'ara-raw',
+      Name: 'ara_raw',
     },
   });
 
   // Test if the Databases names are expected
   expect(dataLakeCatalogStack).toHaveResource('AWS::Glue::Database', {
     DatabaseInput: {
-      Name: 'ara-clean',
+      Name: 'ara_clean',
     },
   });
 
   // Test if the Databases names are expected
   expect(dataLakeCatalogStack).toHaveResource('AWS::Glue::Database', {
     DatabaseInput: {
-      Name: 'ara-transform',
+      Name: 'ara_transform',
     },
   });
 });

--- a/core/test/data-lake-storage.test.ts
+++ b/core/test/data-lake-storage.test.ts
@@ -27,7 +27,7 @@ test('dataLakeStorage', () => {
       'Fn::Join': [
         '',
         [
-          'ara-raw',
+          'ara-raw-',
           {
             Ref: 'AWS::AccountId',
           },
@@ -67,7 +67,7 @@ test('dataLakeStorage', () => {
       'Fn::Join': [
         '',
         [
-          'ara-clean',
+          'ara-clean-',
           {
             Ref: 'AWS::AccountId',
           },
@@ -107,7 +107,7 @@ test('dataLakeStorage', () => {
       'Fn::Join': [
         '',
         [
-          'ara-transform',
+          'ara-transform-',
           {
             Ref: 'AWS::AccountId',
           },


### PR DESCRIPTION
… databases

Issue #, if available:

Description of changes: 

- change names of the DataLakeStorage buckets with '-' before the account ID
- change names of the DataLakeCatalog databases with '_' instead of '-'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.