### PR TITLE
fix: recursive delete of athena workgroup

### DIFF
--- a/core/src/athena-default-setup.ts
+++ b/core/src/athena-default-setup.ts
@@ -38,6 +38,7 @@ export class AthenaDefaultSetup extends Construct {
 
     new CfnWorkGroup(this, 'athenaDefaultWorkgroup', {
       name: 'default',
+      recursiveDeleteOption: true,
       workGroupConfiguration: {
         publishCloudWatchMetricsEnabled: false,
         resultConfiguration: {


### PR DESCRIPTION
Issue #, if available:

Description of changes: delete the athena default workgroup recursively

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.