### PR TITLE
fix: bump to log4j 2.16 to avoid vulnerability

### DIFF
--- a/refarch/aws-native/streaming/stream-processing/pom.xml
+++ b/refarch/aws-native/streaming/stream-processing/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/refarch/aws-native/streaming/stream-processing/pom.xml
+++ b/refarch/aws-native/streaming/stream-processing/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.14.1</version>
+            <version>2.16.0</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Update log4j version to avoid CVE-2021-44228

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.