### PR TITLE
fix: exclude example.ts from documentation

### DIFF
--- a/core/API.md
+++ b/core/API.md
@@ -1664,11 +1664,6 @@ public readonly sharedDefaultConfig: string;
 
 ### Example <a name="Example" id="aws-analytics-reference-architecture.Example"></a>
 
-Example Construct to help onboarding contributors.
-
-This example includes best practices for code comment/documentation generation,
-and for default parameters pattern in CDK using Props with Optional properties
-
 #### Initializers <a name="Initializers" id="aws-analytics-reference-architecture.Example.Initializer"></a>
 
 ```typescript
@@ -5334,8 +5329,6 @@ name of the Amazon EKS namespace to be linked to the Amazon EMR virtual cluster.
 ---
 
 ### ExampleProps <a name="ExampleProps" id="aws-analytics-reference-architecture.ExampleProps"></a>
-
-The properties for the Example Construct class.
 
 #### Initializer <a name="Initializer" id="aws-analytics-reference-architecture.ExampleProps.Initializer"></a>
 

--- a/core/src/example.ts
+++ b/core/src/example.ts
@@ -4,6 +4,8 @@
 import { Construct, CfnOutput } from '@aws-cdk/core';
 
 /**
+ * @ignore
+ * // DO NOT include ignore tag, if you do TypeDoc will not include documentation of your construct
  * The properties for the Example Construct class.
  */
 
@@ -21,6 +23,8 @@ export interface ExampleProps {
 }
 
 /**
+ * @ignore
+ * // DO NOT include ignore tag, if you do TypeDoc will not include documentation of your construct
  * Example Construct to help onboarding contributors.
  * This example includes best practices for code comment/documentation generation,
  * and for default parameters pattern in CDK using Props with Optional properties
@@ -29,6 +33,8 @@ export interface ExampleProps {
 export class Example extends Construct {
 
   /**
+   * @ignore
+   * // DO NOT include ignore tag, if you do TypeDoc will not include documentation of your construct
    * Constructs a new instance of the Example class with CfnOutput.
    * CfnOutput can be customized.
    * @param {Construct} scope the Scope of the CDK Construct


### PR DESCRIPTION
Issue #, if available:

Description of changes: This change Imporve the documentation by adding the ignore tag for TypeDoc to not include example.ts in API.md and not have it in construct hub

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.