### PR TITLE
fix: fix an issue causing k8s autoscaler to fail deploying

### DIFF
--- a/core/src/emr-eks-platform/emr-eks-cluster.ts
+++ b/core/src/emr-eks-platform/emr-eks-cluster.ts
@@ -154,6 +154,7 @@ export class EmrEksCluster extends Construct {
     this.eksCluster.addHelmChart('AutoScaler', {
       chart: 'cluster-autoscaler',
       repository: 'https://kubernetes.github.io/autoscaler',
+      version: '9.11.0',
       namespace: 'kube-system',
       timeout: Duration.minutes(14),
       values: {


### PR DESCRIPTION
Issue #, if available:

Description of changes: Fix the version of k8s autoscaler that is deployed. The newer version cause the autoscaler deployment to fail 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.