### PR TITLE
fix: reduce lambda memory for batchreplayer

### DIFF
--- a/core/src/data-generator/batch-replayer.ts
+++ b/core/src/data-generator/batch-replayer.ts
@@ -124,7 +124,7 @@ export class BatchReplayer extends Construct {
      * Rewrite data
      */
     const writeInBatchFn = new PreBundledFunction(this, 'WriteInBatch', {
-      memorySize: 1024 * 5,
+      memorySize: 3008,
       codePath: 'data-generator/resources/lambdas/write-in-batch',
       runtime: Runtime.PYTHON_3_8,
       handler: 'write-in-batch.handler',


### PR DESCRIPTION
Issue #, if available:

Description of changes: reduce the memory used by the batchReplayer to match default Lambda limits for newly created accounts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.