### PR TITLE
fix: db-shema-manager e2e test fix working around stack deletion issue

### DIFF
--- a/core/.projen/tasks.json
+++ b/core/.projen/tasks.json
@@ -90,13 +90,13 @@
           "exec": "jsii --silence-warnings=reserved-word"
         },
         {
+          "exec": "npx projen gradle-build"
+        },
+        {
           "exec": "npx projen copy-resources"
         },
         {
           "exec": "npx projen pip-install"
-        },
-        {
-          "exec": "npx projen gradle-build"
         }
       ]
     },
@@ -112,6 +112,9 @@
         },
         {
           "exec": "rsync -avr --exclude '*.ts' --exclude '*.js' src/db-schema-manager/resources lib/db-schema-manager"
+        },
+        {
+          "exec": "rsync -avr --exclude '*.ts' --exclude '*.js' src/db-schema-manager/resources/flyway-lambda/build/resources lib/db-schema-manager/resources/flyway-lambda/build"
         },
         {
           "exec": "rsync -avr --exclude '*.ts' --exclude '*.js' src/db-schema-manager/resources/flyway-lambda/src/main/resources lib/db-schema-manager/resources/flyway-lambda/src/main"
@@ -177,7 +180,7 @@
       "description": "./gradlew shadowJar all folders in lib that has requirements.txt",
       "steps": [
         {
-          "exec": "cd lib/db-schema-manager/resources/flyway-lambda && ./gradlew shadowJar && cp build/libs/*.jar ./ 2> /dev/null"
+          "exec": "cd src/db-schema-manager/resources/flyway-lambda && ./gradlew shadowJar && cp build/libs/*.jar ./ 2> /dev/null"
         }
       ]
     },

--- a/core/.projen/tasks.json
+++ b/core/.projen/tasks.json
@@ -114,9 +114,6 @@
           "exec": "rsync -avr --exclude '*.ts' --exclude '*.js' src/db-schema-manager/resources lib/db-schema-manager"
         },
         {
-          "exec": "rsync -avr --exclude '*.ts' --exclude '*.js' src/db-schema-manager/resources/flyway-lambda/build/resources lib/db-schema-manager/resources/flyway-lambda/build"
-        },
-        {
           "exec": "rsync -avr --exclude '*.ts' --exclude '*.js' src/db-schema-manager/resources/flyway-lambda/src/main/resources lib/db-schema-manager/resources/flyway-lambda/src/main"
         },
         {

--- a/core/.projenrc.js
+++ b/core/.projenrc.js
@@ -191,12 +191,10 @@ const gradleBuildTask = project.addTask('gradle-build', {
   description: './gradlew shadowJar all folders in lib that has requirements.txt',
 });
 
-for (const dirPath of findAllGradleLambdaDir('src')) {
+for (const gradlePath of findAllGradleLambdaDir('src')) {
   console.log('loop over gradle dir');
-  // Assume that all folders with 'requirements.txt' have been copied to lib
-  // by the task 'copy-resources'
-  const dirPathInLib = dirname(dirPath.replace('src', 'lib'));
-  const gradleCmd = `cd ${dirPathInLib} && ./gradlew shadowJar && cp build/libs/*.jar ./ 2> /dev/null`;
+  const dirPath = dirname(gradlePath);
+  const gradleCmd = `cd ${dirPath} && ./gradlew shadowJar && cp build/libs/*.jar ./ 2> /dev/null`;
 
   gradleBuildTask.exec(gradleCmd);
 }
@@ -204,9 +202,9 @@ for (const dirPath of findAllGradleLambdaDir('src')) {
 /**
  * Run `copy-resources` and `pip-install` as part of compile
  */
+project.compileTask.exec('npx projen gradle-build');
 project.compileTask.exec('npx projen copy-resources');
 project.compileTask.exec('npx projen pip-install');
-project.compileTask.exec('npx projen gradle-build');
 
 /**
  * Find all directory that has a Python package.

--- a/core/src/db-schema-manager/flyway-runner.ts
+++ b/core/src/db-schema-manager/flyway-runner.ts
@@ -170,7 +170,9 @@ export class FlywayRunner extends cdk.Construct {
         assetHash: (migrationFilesDeployment.node.findChild('Asset1') as Asset).assetHash,
       },
     });
-
+    for(const subnet of props.vpc.privateSubnets) {
+      flywayLambda.node.addDependency(subnet);
+    }
     flywayCustomResourceProvider.node.addDependency(migrationFilesDeployment);
   }
 }

--- a/core/src/db-schema-manager/resources/flyway-lambda/.gitignore
+++ b/core/src/db-schema-manager/resources/flyway-lambda/.gitignore
@@ -10,3 +10,6 @@ gradle-app.setting
 
 # Cache of project
 .gradletasknamecache
+
+
+flyway-all.jar


### PR DESCRIPTION
Fix #328 

Description of changes:
* Build jar in src before moving files to lib
* Ignore it in git
* Add retry in test to delete the stack properly

This enable to 
* have the jar available for jest test
* have a working teardown

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.