### PR TITLE
fix: lf s3 location

### DIFF
--- a/core/API.md
+++ b/core/API.md
@@ -3129,18 +3129,16 @@ public readonly iamRole: Role;
 This CDK construct aims to register an S3 Location for Lakeformation with Read and Write access.
 
 If the location is in a different account, cross account access should be granted via the [S3CrossAccount]{@link S3CrossAccount} construct.
+If the S3 location is encrypted with KMS, the key must be explicitly passed to the construct because CDK cannot retrieve bucket encryption key from imported buckets. 
+Imported buckets are generally used in cross account setup like data mesh.
 
 This construct instantiate 2 objects:
-* An IAM role with read/write permissions to the S3 location and read access to the KMS key used to encypt the bucket
-* A CfnResource is based on an IAM role with 2 policies folowing the least privilege AWS best practices:
-* Policy 1 is for GetObject, PutObject, DeleteObject from S3 bucket
-* Policy 2 is to list S3 Buckets
+* An IAM role with read/write permissions to the S3 location and encrypt/decrypt access to the KMS key used to encypt the bucket
+* A CfnResource is based on an IAM role with 2 policy statement folowing the least privilege AWS best practices:
+   * Statement 1 for S3 permissions
+   * Statement 2 for KMS permissions if the bucket is encrypted
 
-Policy 1 takes as an input S3 object arn
-Policy 2 takes as an input S3 bucket arn
-
-
-The CDK construct instantiate the cfnresource in order to register the S3 location with Lakeformation using the IAM role defined above.
+The CDK construct instantiate the CfnResource in order to register the S3 location with Lakeformation using the IAM role defined above.
 
 Usage example:
 ```typescript
@@ -6753,7 +6751,8 @@ const lakeFormationS3LocationProps: LakeFormationS3LocationProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-analytics-reference-architecture.LakeFormationS3LocationProps.property.s3Bucket">s3Bucket</a></code> | <code>aws-cdk-lib.aws_s3.Bucket</code> | S3 Bucket to be registered with Lakeformation. |
+| <code><a href="#aws-analytics-reference-architecture.LakeFormationS3LocationProps.property.s3Bucket">s3Bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | S3 Bucket to be registered with Lakeformation. |
+| <code><a href="#aws-analytics-reference-architecture.LakeFormationS3LocationProps.property.kmsKey">kmsKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | KMS key used to encrypt the S3 Location. |
 | <code><a href="#aws-analytics-reference-architecture.LakeFormationS3LocationProps.property.s3ObjectKey">s3ObjectKey</a></code> | <code>string</code> | S3 object key to be registered with Lakeformation. |
 
 ---
@@ -6761,12 +6760,25 @@ const lakeFormationS3LocationProps: LakeFormationS3LocationProps = { ... }
 ##### `s3Bucket`<sup>Required</sup> <a name="s3Bucket" id="aws-analytics-reference-architecture.LakeFormationS3LocationProps.property.s3Bucket"></a>
 
 ```typescript
-public readonly s3Bucket: Bucket;
+public readonly s3Bucket: IBucket;
 ```
 
-- *Type:* aws-cdk-lib.aws_s3.Bucket
+- *Type:* aws-cdk-lib.aws_s3.IBucket
 
 S3 Bucket to be registered with Lakeformation.
+
+---
+
+##### `kmsKey`<sup>Optional</sup> <a name="kmsKey" id="aws-analytics-reference-architecture.LakeFormationS3LocationProps.property.kmsKey"></a>
+
+```typescript
+public readonly kmsKey: IKey;
+```
+
+- *Type:* aws-cdk-lib.aws_kms.IKey
+- *Default:* No encryption is used
+
+KMS key used to encrypt the S3 Location.
 
 ---
 

--- a/core/src/integ.default.ts
+++ b/core/src/integ.default.ts
@@ -1,25 +1,18 @@
-import { Key } from 'aws-cdk-lib/aws-kms';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
-import { App, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { App, Stack } from 'aws-cdk-lib';
 // eslint-disable-next-line import/no-extraneous-dependencies,import/no-unresolved
-import { BatchReplayer, PreparedDataset } from './data-generator';
+import { LakeformationS3Location } from './lf-s3-location';
+import { Key } from 'aws-cdk-lib/aws-kms';
 
 
 const mockApp = new App();
 const stack = new Stack(mockApp, 'test');
 
-const myKey = new Key(stack, 'MyKey', {
-  removalPolicy: RemovalPolicy.DESTROY,
-});
+const myBucket = Bucket.fromBucketName(stack, 'mybucket', 'xxxxxxxxxx');
+const myKey = Key.fromKeyArn(stack, 'Key', 'xxxxxxxxxx');
 
-const myBucket = new Bucket(stack, 'MyBucket', {
-  encryptionKey: myKey,
-  removalPolicy: RemovalPolicy.DESTROY,
-  autoDeleteObjects: true,
-});
-
-new BatchReplayer(stack, 'test', {
-  dataset: PreparedDataset.RETAIL_1_GB_CUSTOMER,
-  sinkBucket: myBucket,
-  sinkObjectKey: 'test',
+new LakeformationS3Location(stack, 'Location', {
+  s3Bucket: myBucket,
+  s3ObjectKey: 'test',
+  kmsKey: myKey,
 });

--- a/core/src/lf-s3-location.ts
+++ b/core/src/lf-s3-location.ts
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { IKey } from 'aws-cdk-lib/aws-kms';
 import * as lakeformation from 'aws-cdk-lib/aws-lakeformation';
-import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
 /**
@@ -13,29 +14,32 @@ export interface LakeFormationS3LocationProps {
   /**
    * S3 Bucket to be registered with Lakeformation
    */
-  readonly s3Bucket: Bucket;
+  readonly s3Bucket: IBucket;
   /**
    * S3 object key to be registered with Lakeformation
    * @default - The entire bucket is registered
    */
   readonly s3ObjectKey?: string;
+  /**
+   * KMS key used to encrypt the S3 Location
+   * @default - No encryption is used
+   */
+  readonly kmsKey?: IKey;
 }
 
 /**
  * This CDK construct aims to register an S3 Location for Lakeformation with Read and Write access.
  * If the location is in a different account, cross account access should be granted via the [S3CrossAccount]{@link S3CrossAccount} construct.
+ * If the S3 location is encrypted with KMS, the key must be explicitly passed to the construct because CDK cannot retrieve bucket encryption key from imported buckets. 
+ * Imported buckets are generally used in cross account setup like data mesh.
  *
  * This construct instantiate 2 objects:
- * * An IAM role with read/write permissions to the S3 location and read access to the KMS key used to encypt the bucket
- * * A CfnResource is based on an IAM role with 2 policies folowing the least privilege AWS best practices:
- * * Policy 1 is for GetObject, PutObject, DeleteObject from S3 bucket
- * * Policy 2 is to list S3 Buckets
+ * * An IAM role with read/write permissions to the S3 location and encrypt/decrypt access to the KMS key used to encypt the bucket
+ * * A CfnResource is based on an IAM role with 2 policy statement folowing the least privilege AWS best practices:
+ *   * Statement 1 for S3 permissions
+ *   * Statement 2 for KMS permissions if the bucket is encrypted
  *
- * Policy 1 takes as an input S3 object arn
- * Policy 2 takes as an input S3 bucket arn
- *
- *
- * The CDK construct instantiate the cfnresource in order to register the S3 location with Lakeformation using the IAM role defined above.
+ * The CDK construct instantiate the CfnResource in order to register the S3 location with Lakeformation using the IAM role defined above.
  *
  * Usage example:
  * ```typescript
@@ -66,40 +70,46 @@ export class LakeformationS3Location extends Construct {
     });
 
     const objectKey = props.s3ObjectKey ? props.s3ObjectKey + '/*' : '*';
-    // add policy to access S3 for Read and Write
-    // this.dataAccessRole.addToPolicy(
-    //   new PolicyStatement({
-    //     resources: [
-    //       props.s3Bucket.arnForObjects(objectKey),
-    //       props.s3Bucket.bucketArn,
-    //     ],
-    //     actions: [
-    //       's3:GetObject',
-    //       's3:PutObject',
-    //       's3:DeleteObject',
-    //       's3:ListBucketMultipartUploads',
-    //       's3:ListMultipartUploadParts',
-    //       's3:AbortMultipartUpload',
-    //       's3:ListBucket',
-    //     ],
-    //   }),
-    // );
+    //add policy to access S3 for Read and Write
+    this.dataAccessRole.addToPolicy(
+      new PolicyStatement({
+        resources: [
+          props.s3Bucket.arnForObjects(objectKey),
+          props.s3Bucket.bucketArn,
+        ],
+        actions: [
+          "s3:GetObject*",
+          "s3:GetBucket*",
+          "s3:List*",
+          "s3:DeleteObject*",
+          "s3:PutObject",
+          "s3:PutObjectLegalHold",
+          "s3:PutObjectRetention",
+          "s3:PutObjectTagging",
+          "s3:PutObjectVersionTagging",
+          "s3:Abort*",
+        ],
+      }),
+    );
 
-    // // add policy to access KMS key used for the bucket encryption
-    // if (bucket.encryptionKey) {
-    //   this.dataAccessRole.addToPolicy(
-    //     new PolicyStatement({
-    //       resources: [
-    //         bucket.encryptionKey?.keyArn,
-    //       ],
-    //       actions: [
-    //         'kms:Decrypt',
-    //       ],
-    //     }),
-    //   );
-    // }
-
-    props.s3Bucket.grantReadWrite(this.dataAccessRole, objectKey);
+    // add policy to access KMS key used for the bucket encryption
+    if (props.kmsKey) {
+      this.dataAccessRole.addToPolicy(
+        new PolicyStatement({
+          resources: [
+            props.kmsKey?.keyArn,
+          ],
+          actions: [
+            'kms:Encrypt*',
+            'kms:Decrypt*',
+            'kms:ReEncrypt*',
+            'kms:GenerateDataKey*',
+            'kms:Describe*',
+          ],
+        }),
+      );
+    }
+    //props.s3Bucket.grantReadWrite(this.dataAccessRole, objectKey);
 
     new lakeformation.CfnResource(this, 'MyCfnResource', {
       resourceArn: props.s3Bucket.arnForObjects(objectKey),

--- a/core/test/e2e/lf-s3-location.test.ts
+++ b/core/test/e2e/lf-s3-location.test.ts
@@ -30,6 +30,7 @@ const myBucket = new Bucket(stack, 'MyBucket', {
 const s3Location = new LakeformationS3Location(stack, 'S3Location', {
   s3Bucket: myBucket,
   s3ObjectKey: 'test',
+  kmsKey: myKey,
 });
 
 new cdk.CfnOutput(stack, 'BucketPolicy', {

--- a/core/test/unit/cdk-nag/nag-lf-s3-location.test.ts
+++ b/core/test/unit/cdk-nag/nag-lf-s3-location.test.ts
@@ -8,21 +8,27 @@
  */
 
 import { Annotations, Match } from 'aws-cdk-lib/assertions';
-import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { App, Aspects, Stack } from 'aws-cdk-lib';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 import { LakeformationS3Location } from '../../../src/lf-s3-location';
+import { Key } from 'aws-cdk-lib/aws-kms';
 
 const mockApp = new App();
 
 const lfS3LocationStack = new Stack(mockApp, 'LfS3LocationStack');
-const bucket = new Bucket(lfS3LocationStack, 'Bucket');
+const key = new Key(lfS3LocationStack,'Key');
+const bucket = new Bucket(lfS3LocationStack, 'Bucket', {
+  encryption: BucketEncryption.KMS,
+  encryptionKey: key,
+});
 
 // Instantiate LakeFormationS3Location Construct
 new LakeformationS3Location(lfS3LocationStack, 'LfS3Location', {
   s3Bucket: bucket,
   s3ObjectKey: 'test',
+  kmsKey: key,
 });
 
 Aspects.of(lfS3LocationStack).add(new AwsSolutionsChecks());
@@ -31,6 +37,12 @@ NagSuppressions.addResourceSuppressionsByPath(
   lfS3LocationStack,
   'LfS3LocationStack/LfS3Location/LFS3AccessRole/DefaultPolicy/Resource',
   [{ id: 'AwsSolutions-IAM5', reason: 'The S3 location role needs access to all the objects under the prefix' }],
+);
+
+NagSuppressions.addResourceSuppressionsByPath(
+  lfS3LocationStack,
+  'LfS3LocationStack/Key/Resource',
+  [{ id: 'AwsSolutions-KMS5', reason: 'The KMS Key is not in the scope of the test' }],
 );
 
 NagSuppressions.addResourceSuppressionsByPath(


### PR DESCRIPTION
Issue #, if available: #361

Description of changes:  fix the permissions for the LakeFormationS3Location so it supports S3 buckets and KMS keys in a different account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.