### PR TITLE
fix: glue default role kms permissions

### DIFF
--- a/core/API.md
+++ b/core/API.md
@@ -3835,9 +3835,9 @@ public readonly runner: CustomResource;
 ---
 
 
-### GlueDefaultRole <a name="GlueDefaultRole" id="aws-analytics-reference-architecture.GlueDefaultRole"></a>
+### GlueDemoRole <a name="GlueDemoRole" id="aws-analytics-reference-architecture.GlueDemoRole"></a>
 
-SingletonGlueDefaultRole Construct to automatically setup a new Amazon IAM role to use with AWS Glue jobs.
+GlueDemoRole Construct to automatically setup a new Amazon IAM role to use with AWS Glue jobs.
 
 The role is created with AWSGlueServiceRole policy and authorize all actions on S3.
 If you would like to scope down the permission you should create a new role with a scoped down policy
@@ -3847,11 +3847,11 @@ The Construct provides a getOrCreate method for SingletonInstantiation
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-analytics-reference-architecture.GlueDefaultRole.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#aws-analytics-reference-architecture.GlueDemoRole.toString">toString</a></code> | Returns a string representation of this construct. |
 
 ---
 
-##### `toString` <a name="toString" id="aws-analytics-reference-architecture.GlueDefaultRole.toString"></a>
+##### `toString` <a name="toString" id="aws-analytics-reference-architecture.GlueDemoRole.toString"></a>
 
 ```typescript
 public toString(): string
@@ -3863,17 +3863,17 @@ Returns a string representation of this construct.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#aws-analytics-reference-architecture.GlueDefaultRole.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#aws-analytics-reference-architecture.GlueDefaultRole.getOrCreate">getOrCreate</a></code> | *No description.* |
+| <code><a href="#aws-analytics-reference-architecture.GlueDemoRole.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#aws-analytics-reference-architecture.GlueDemoRole.getOrCreate">getOrCreate</a></code> | *No description.* |
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="aws-analytics-reference-architecture.GlueDefaultRole.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="aws-analytics-reference-architecture.GlueDemoRole.isConstruct"></a>
 
 ```typescript
-import { GlueDefaultRole } from 'aws-analytics-reference-architecture'
+import { GlueDemoRole } from 'aws-analytics-reference-architecture'
 
-GlueDefaultRole.isConstruct(x: any)
+GlueDemoRole.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
@@ -3892,7 +3892,7 @@ library can be accidentally installed, and `instanceof` will behave
 unpredictably. It is safest to avoid using `instanceof`, and using
 this type-testing method instead.
 
-###### `x`<sup>Required</sup> <a name="x" id="aws-analytics-reference-architecture.GlueDefaultRole.isConstruct.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="aws-analytics-reference-architecture.GlueDemoRole.isConstruct.parameter.x"></a>
 
 - *Type:* any
 
@@ -3900,15 +3900,15 @@ Any object.
 
 ---
 
-##### `getOrCreate` <a name="getOrCreate" id="aws-analytics-reference-architecture.GlueDefaultRole.getOrCreate"></a>
+##### `getOrCreate` <a name="getOrCreate" id="aws-analytics-reference-architecture.GlueDemoRole.getOrCreate"></a>
 
 ```typescript
-import { GlueDefaultRole } from 'aws-analytics-reference-architecture'
+import { GlueDemoRole } from 'aws-analytics-reference-architecture'
 
-GlueDefaultRole.getOrCreate(scope: Construct)
+GlueDemoRole.getOrCreate(scope: Construct)
 ```
 
-###### `scope`<sup>Required</sup> <a name="scope" id="aws-analytics-reference-architecture.GlueDefaultRole.getOrCreate.parameter.scope"></a>
+###### `scope`<sup>Required</sup> <a name="scope" id="aws-analytics-reference-architecture.GlueDemoRole.getOrCreate.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
@@ -3918,12 +3918,12 @@ GlueDefaultRole.getOrCreate(scope: Construct)
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#aws-analytics-reference-architecture.GlueDefaultRole.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#aws-analytics-reference-architecture.GlueDefaultRole.property.iamRole">iamRole</a></code> | <code>aws-cdk-lib.aws_iam.Role</code> | *No description.* |
+| <code><a href="#aws-analytics-reference-architecture.GlueDemoRole.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#aws-analytics-reference-architecture.GlueDemoRole.property.iamRole">iamRole</a></code> | <code>aws-cdk-lib.aws_iam.Role</code> | *No description.* |
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="aws-analytics-reference-architecture.GlueDefaultRole.property.node"></a>
+##### `node`<sup>Required</sup> <a name="node" id="aws-analytics-reference-architecture.GlueDemoRole.property.node"></a>
 
 ```typescript
 public readonly node: Node;
@@ -3935,7 +3935,7 @@ The tree node.
 
 ---
 
-##### `iamRole`<sup>Required</sup> <a name="iamRole" id="aws-analytics-reference-architecture.GlueDefaultRole.property.iamRole"></a>
+##### `iamRole`<sup>Required</sup> <a name="iamRole" id="aws-analytics-reference-architecture.GlueDemoRole.property.iamRole"></a>
 
 ```typescript
 public readonly iamRole: Role;

--- a/core/src/glue-default-role.ts
+++ b/core/src/glue-default-role.ts
@@ -62,6 +62,16 @@ export class GlueDefaultRole extends Construct {
               resources: ['*'],
               actions: ['lakeformation:GetDataAccess'],
             }),
+            new PolicyStatement({
+              resources: ['*'],
+              actions: [
+                'kms:Encrypt*',
+                'kms:Decrypt*',
+                'kms:ReEncrypt*',
+                'kms:GenerateDataKey*',
+                'kms:Describe*',
+              ],
+            }),
           ],
         }),
       },

--- a/core/src/glue-demo-role.ts
+++ b/core/src/glue-demo-role.ts
@@ -6,24 +6,24 @@ import { Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 /**
- * SingletonGlueDefaultRole Construct to automatically setup a new Amazon IAM role to use with AWS Glue jobs.
+ * GlueDemoRole Construct to automatically setup a new Amazon IAM role to use with AWS Glue jobs.
  * The role is created with AWSGlueServiceRole policy and authorize all actions on S3.
  * If you would like to scope down the permission you should create a new role with a scoped down policy
  * The Construct provides a getOrCreate method for SingletonInstantiation
  */
 
-export class GlueDefaultRole extends Construct {
+export class GlueDemoRole extends Construct {
 
   public static getOrCreate(scope: Construct) {
     const stack = Stack.of(scope);
-    const id = 'GlueDefaultRole';
-    return stack.node.tryFindChild(id) as GlueDefaultRole || new GlueDefaultRole(stack, id);
+    const id = 'GlueDemoRole';
+    return stack.node.tryFindChild(id) as GlueDemoRole || new GlueDemoRole(stack, id);
   }
 
   public readonly iamRole: Role;
 
   /**
-   * Constructs a new instance of the GlueDefaultRole class
+   * Constructs a new instance of the GlueDemoRole class
    * @param {Construct} scope the Scope of the CDK Construct
    * @param {string} id the ID of the CDK Construct
    * @access private
@@ -34,7 +34,7 @@ export class GlueDefaultRole extends Construct {
 
     const stack = Stack.of(this);
 
-    this.iamRole = new Role(this, 'GlueDefaultRole', {
+    this.iamRole = new Role(this, 'GlueDemoRole', {
       assumedBy: new ServicePrincipal('glue.amazonaws.com'),
       managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSGlueServiceRole')],
       inlinePolicies: {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -10,7 +10,7 @@ export { Ec2SsmRole } from './ec2-ssm-role';
 export { DataLakeCatalog } from './data-lake-catalog';
 export { DataLakeExporter, DataLakeExporterProps } from './data-lake-exporter';
 export { AthenaDemoSetup } from './athena-demo-setup';
-export { GlueDefaultRole } from './glue-default-role';
+export { GlueDemoRole } from './glue-demo-role';
 export { EmrEksClusterProps, EmrEksCluster, EmrEksNodegroupOptions, EmrEksNodegroup, EmrVirtualClusterOptions, EmrManagedEndpointOptions } from './emr-eks-platform';
 export { FlywayRunner, FlywayRunnerProps } from './db-schema-manager';
 export { NotebookPlatform, NotebookPlatformProps, StudioAuthMode, IdpRelayState, NotebookUserOptions, NotebookManagedEndpointOptions, SSOIdentityType } from './notebook-platform';

--- a/core/test/e2e/glue-demo-role.test.ts
+++ b/core/test/e2e/glue-demo-role.test.ts
@@ -2,26 +2,26 @@
 // SPDX-License-Identifier: MIT-0
 
 /**
- * Tests GlueDefaultRole
+ * Tests GlueDemoRole
  *
- * @group integ/glue-default-role
+ * @group integ/glue-demo-role
  */
 
  import * as cdk from 'aws-cdk-lib';
  import { deployStack, destroyStack } from './utils';
 
- import { GlueDefaultRole } from '../../src/glue-default-role';
+ import { GlueDemoRole } from '../../src/glue-demo-role';
  
  jest.setTimeout(100000);
  // GIVEN
  const integTestApp = new cdk.App();
- const stack = new cdk.Stack(integTestApp, 'GlueDefaultRoleE2eTest');
+ const stack = new cdk.Stack(integTestApp, 'GlueDemoRoleE2eTest');
  
- const glueDefaultRole = GlueDefaultRole.getOrCreate(stack);
+ const glueDemoRole = GlueDemoRole.getOrCreate(stack);
 
- new cdk.CfnOutput(stack, 'GlueDefaultRoleName', {
-   value: glueDefaultRole.iamRole.roleName,
-   exportName: 'glueDefaultRoleName',
+ new cdk.CfnOutput(stack, 'GlueDemoRoleName', {
+   value: glueDemoRole.iamRole.roleName,
+   exportName: 'glueDemoRoleName',
  });
  
  describe('deploy succeed', () => {
@@ -30,7 +30,7 @@
      const deployResult = await deployStack(integTestApp, stack);
      
      // THEN
-     expect(deployResult.outputs.GlueDefaultRoleName).toContain('GlueDefaultRole');
+     expect(deployResult.outputs.GlueDemoRoleName).toContain('GlueDemoRole');
  
    }, 9000000);
  });

--- a/core/test/unit/cdk-nag/nag-glue-demo-role.test.ts
+++ b/core/test/unit/cdk-nag/nag-glue-demo-role.test.ts
@@ -11,38 +11,38 @@ import { Annotations, Match } from 'aws-cdk-lib/assertions';
 import { App, Aspects, Stack } from 'aws-cdk-lib';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
-import { GlueDefaultRole } from '../../../src/glue-default-role';
+import { GlueDemoRole } from '../../../src/glue-demo-role';
 
 const mockApp = new App();
 
-const glueDefaultRoleStack = new Stack(mockApp, 'GlueDefaultRoleStack');
+const glueDemoRoleStack = new Stack(mockApp, 'GlueDemoRoleStack');
 
-// Instantiate SingletonGlueDefaultRole Construct
-GlueDefaultRole.getOrCreate(glueDefaultRoleStack);
+// Instantiate GlueDemoRole Construct
+GlueDemoRole.getOrCreate(glueDemoRoleStack);
 
-Aspects.of(glueDefaultRoleStack).add(new AwsSolutionsChecks());
+Aspects.of(glueDemoRoleStack).add(new AwsSolutionsChecks());
 
 // Suppressing the warning that the S3 location role needs access to all the objects under the prefix.
 NagSuppressions.addResourceSuppressionsByPath(
-  glueDefaultRoleStack,
-  'GlueDefaultRoleStack/GlueDefaultRole/GlueDefaultRole/Resource',
+  glueDemoRoleStack,
+  'GlueDemoRoleStack/GlueDemoRole/GlueDemoRole/Resource',
   [{ id: 'AwsSolutions-IAM5', reason: 'The role needs wide access to S3' }],
 );
 
 NagSuppressions.addResourceSuppressionsByPath(
-  glueDefaultRoleStack,
-  'GlueDefaultRoleStack/GlueDefaultRole/GlueDefaultRole/Resource',
+  glueDemoRoleStack,
+  'GlueDemoRoleStack/GlueDemoRole/GlueDemoRole/Resource',
   [{ id: 'AwsSolutions-IAM4', reason: 'The role uses AWSGlueServiceRole managed policy as a default policy for using Glue' }],
 );
 
 test('No unsuppressed Warnings', () => {
-  const warnings = Annotations.fromStack(glueDefaultRoleStack).findWarning('*', Match.stringLikeRegexp('AwsSolutions-.*'));
+  const warnings = Annotations.fromStack(glueDemoRoleStack).findWarning('*', Match.stringLikeRegexp('AwsSolutions-.*'));
   console.log(warnings);
   expect(warnings).toHaveLength(0);
 });
 
 test('No unsuppressed Errors', () => {
-  const errors = Annotations.fromStack(glueDefaultRoleStack).findError('*', Match.stringLikeRegexp('AwsSolutions-.*'));
+  const errors = Annotations.fromStack(glueDemoRoleStack).findError('*', Match.stringLikeRegexp('AwsSolutions-.*'));
   console.log(errors);
   expect(errors).toHaveLength(0);
 });

--- a/core/test/unit/glue-demo-role.test.ts
+++ b/core/test/unit/glue-demo-role.test.ts
@@ -8,20 +8,20 @@
  */
 
 import { Stack } from 'aws-cdk-lib';
-import { GlueDefaultRole } from '../../src/glue-default-role';
+import { GlueDemoRole } from '../../src/glue-demo-role';
 import { Template, Match } from 'aws-cdk-lib/assertions';
 
-test('SingletonGlueDefaultRole', () => {
+test('GlueDemoRole', () => {
 
-  const glueDefaultRoleStack = new Stack();
+  const glueDemoRoleStack = new Stack();
 
-  // Instantiate 2 SingletonGlueDefaultRole Constructs
-  GlueDefaultRole.getOrCreate(glueDefaultRoleStack);
-  GlueDefaultRole.getOrCreate(glueDefaultRoleStack);
+  // Instantiate 2 GlueDemoRole Constructs
+  GlueDemoRole.getOrCreate(glueDemoRoleStack);
+  GlueDemoRole.getOrCreate(glueDemoRoleStack);
 
-  const template = Template.fromStack(glueDefaultRoleStack);
+  const template = Template.fromStack(glueDemoRoleStack);
 
-  // Test if SingletonGlueDefaultRole is a singleton
+  // Test if GlueDemoRole is a singleton
   template.resourceCountIs('AWS::IAM::Role', 1);
 
   // Test the created Amazon IAM Role


### PR DESCRIPTION
Issue #, if available:

Description of changes: fix permissions on GlueDefaultRole and rename to GlueDemoRole

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.