### PR TITLE
fix: change lambda size for data generator to fit in new AWS accounts…

### DIFF
--- a/core/src/data-generator/batch-replayer.ts
+++ b/core/src/data-generator/batch-replayer.ts
@@ -186,7 +186,7 @@ export class BatchReplayer extends Construct {
      * Rewrite data
      */
     const writeInBatchFn = new PreBundledFunction(this, 'WriteInBatch', {
-      memorySize: 1024 * 3,
+      memorySize: 3008,
       codePath: 'data-generator/resources/lambdas/write-in-batch',
       runtime: Runtime.PYTHON_3_9,
       handler: 'write-in-batch.handler',


### PR DESCRIPTION
… limits

Issue #, if available:

Description of changes: downsize the lambda memory size for `DataGenerator` so it can fit in new AWS accounts limits (3008MB)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.