### PR TITLE
fix: Add domain specific identifier to domain secret

### DIFF
--- a/core/src/data-mesh/central-governance.ts
+++ b/core/src/data-mesh/central-governance.ts
@@ -226,7 +226,7 @@ export class CentralGovernance extends Construct {
   public registerDataDomain(id: string, domainId: string, domainName: string, domainSecretArn: string) {
 
     // Import the data domain secret from it's full ARN
-    const domainSecret = Secret.fromSecretCompleteArn(this, 'DomainSecret', domainSecretArn);
+    const domainSecret = Secret.fromSecretCompleteArn(this, `${id}DomainSecret`, domainSecretArn);
     // Extract data domain references
     const domainBucket = domainSecret.secretValueFromJson('BucketName').unsafeUnwrap();
     const domainPrefix = domainSecret.secretValueFromJson('Prefix').unsafeUnwrap();


### PR DESCRIPTION
Issue #438, if available:

Description of changes: Add custom identifier to `DomainSecret` to enable multiple data domains to be registered.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.