### PR TITLE
fix: typo in construct name

### DIFF
--- a/core/src/data-mesh/central-governance.ts
+++ b/core/src/data-mesh/central-governance.ts
@@ -293,7 +293,7 @@ export class CentralGovernance extends Construct {
     rule.addTarget(new targets.EventBus(
       EventBus.fromEventBusArn(
         this,
-        '${id}DomainEventBus',
+        `${id}DomainEventBus`,
         dataDomainBusArn
       )),
     );


### PR DESCRIPTION
Issue #440, if available:

Description of changes: Fix typo that caused ill formed interpolation in construct id.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.