### PR TITLE
fix: add domain account id for LF S3 location construct

### DIFF
--- a/core/src/data-mesh/central-governance.ts
+++ b/core/src/data-mesh/central-governance.ts
@@ -240,6 +240,7 @@ export class CentralGovernance extends Construct {
         bucketName: domainBucket,
         objectKey: domainPrefix,
       },
+      accountId: domainId,
       kmsKeyId: domainKey,
     });
 


### PR DESCRIPTION
Issue #442, if available:

Description of changes: Add data domain account id to `LFS3Location` when registering new data domain.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.