### PR TITLE
fix: IAM permission for execution role to access pod template

### DIFF
--- a/core/src/emr-eks-platform/emr-eks-cluster.ts
+++ b/core/src/emr-eks-platform/emr-eks-cluster.ts
@@ -378,7 +378,7 @@ export class EmrEksCluster extends TrackedConstruct {
     // store the OIDC provider for creating execution roles later
     this.eksOidcProvider = new FederatedPrincipal(
       this.eksCluster.openIdConnectProvider.openIdConnectProviderArn,
-      {...[]},
+      { ...[] },
       'sts:AssumeRoleWithWebIdentity',
     );
 
@@ -942,7 +942,7 @@ ${userData.join('\r\n')}
                   account: '',
                   service: 's3',
                   resource: this.podTemplateLocation.bucketName,
-                  resourceName: this.podTemplateLocation.objectKey,
+                  resourceName: `${this.podTemplateLocation.objectKey}/*`,
                 }),
               ],
             }),

--- a/core/test/unit/cdk-nag/nag-notebook-platform.test.ts
+++ b/core/test/unit/cdk-nag/nag-notebook-platform.test.ts
@@ -487,6 +487,15 @@ NagSuppressions.addResourceSuppressionsByPath(
 
 NagSuppressions.addResourceSuppressionsByPath(
   stack,
+  '/eks-emr-studio/eks-emr-studio/lotfi-emr-advanced0ExecutionRole/Resource',
+  [{
+    id: 'AwsSolutions-IAM5',
+    reason: 'Wild card needed in path "data-platform/pod-template/*" to allow access to all pod templates',
+  }],
+);
+
+NagSuppressions.addResourceSuppressionsByPath(
+  stack,
   'eks-emr-studio/data-platform/AsgTagProvider/CustomResourceProvider/framework-onEvent/Resource',
   [{ id: 'AwsSolutions-L1', reason: 'Runtime set the by the L2 construct, cannot be changed' }],
 );


### PR DESCRIPTION
Issue #, if available:

Description of changes: The current default IAM appended to the execution role is not enough to access the pod template. This PR append a wild card to the policy to access the pod template bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.