### PR TITLE
fix: remove unused KMS alias for singleton kms key

### DIFF
--- a/core/src/singleton-kms-key.ts
+++ b/core/src/singleton-kms-key.ts
@@ -20,9 +20,8 @@ export class SingletonKey extends Key {
     const id = `${keyName}`;
 
     const stackKey = stack.node.tryFindChild(id) as Key ?? (stack.nestedStackParent ? stack.nestedStackParent.node.tryFindChild(id) as Key : undefined);
-    
+
     return stackKey || new Key(stack, id, {
-      alias: `${keyName}-${Stack.of(stack).stackName}`,
       enableKeyRotation: true,
       removalPolicy: RemovalPolicy.DESTROY,
     });


### PR DESCRIPTION
Issue #, if available:

Description of changes: Remove unused KMS key alias.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.