### PR TITLE
fix: add parameter to customize athena workgroup setup

### DIFF
--- a/core/API.md
+++ b/core/API.md
@@ -1157,13 +1157,14 @@ AthenaDemoSetup Construct to automatically setup a new Amazon Athena Workgroup w
 ```typescript
 import { AthenaDemoSetup } from 'aws-analytics-reference-architecture'
 
-new AthenaDemoSetup(scope: Construct, id: string)
+new AthenaDemoSetup(scope: Construct, id: string, props: AthenaDemoSetupProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#aws-analytics-reference-architecture.AthenaDemoSetup.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | the Scope of the CDK Construct. |
 | <code><a href="#aws-analytics-reference-architecture.AthenaDemoSetup.Initializer.parameter.id">id</a></code> | <code>string</code> | the ID of the CDK Construct. |
+| <code><a href="#aws-analytics-reference-architecture.AthenaDemoSetup.Initializer.parameter.props">props</a></code> | <code><a href="#aws-analytics-reference-architecture.AthenaDemoSetupProps">AthenaDemoSetupProps</a></code> | *No description.* |
 
 ---
 
@@ -1180,6 +1181,12 @@ the Scope of the CDK Construct.
 - *Type:* string
 
 the ID of the CDK Construct.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="aws-analytics-reference-architecture.AthenaDemoSetup.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#aws-analytics-reference-architecture.AthenaDemoSetupProps">AthenaDemoSetupProps</a>
 
 ---
 
@@ -6906,6 +6913,39 @@ public readonly versioned: boolean;
 - *Default:* false
 
 Whether this bucket should have versioning turned on or not.
+
+---
+
+### AthenaDemoSetupProps <a name="AthenaDemoSetupProps" id="aws-analytics-reference-architecture.AthenaDemoSetupProps"></a>
+
+#### Initializer <a name="Initializer" id="aws-analytics-reference-architecture.AthenaDemoSetupProps.Initializer"></a>
+
+```typescript
+import { AthenaDemoSetupProps } from 'aws-analytics-reference-architecture'
+
+const athenaDemoSetupProps: AthenaDemoSetupProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#aws-analytics-reference-architecture.AthenaDemoSetupProps.property.workgroupName">workgroupName</a></code> | <code>string</code> | The Amazon Athena workgroup name. |
+
+---
+
+##### `workgroupName`<sup>Optional</sup> <a name="workgroupName" id="aws-analytics-reference-architecture.AthenaDemoSetupProps.property.workgroupName"></a>
+
+```typescript
+public readonly workgroupName: string;
+```
+
+- *Type:* string
+- *Default:* `demo` is used
+
+The Amazon Athena workgroup name.
+
+The name is also used
 
 ---
 

--- a/core/src/athena-demo-setup.ts
+++ b/core/src/athena-demo-setup.ts
@@ -6,6 +6,15 @@ import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { AraBucket } from './ara-bucket';
 
+export interface AthenaDemoSetupProps {
+
+  /**
+   * The Amazon Athena workgroup name. The name is also used 
+   * @default - `demo` is used
+   */
+  readonly workgroupName?: string;
+}
+
 /**
  * AthenaDemoSetup Construct to automatically setup a new Amazon Athena Workgroup with proper configuration for out-of-the-box demo
  */
@@ -22,17 +31,18 @@ export class AthenaDemoSetup extends Construct {
    * @access public
    */
 
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props: AthenaDemoSetupProps) {
     super(scope, id);
 
+    const workgroupName = props.workgroupName || 'demo'; 
     // Singleton Amazon S3 bucket for Amazon Athena Query logs
     this.resultBucket = AraBucket.getOrCreate(this, {
-      bucketName: 'athena-logs',
-      serverAccessLogsPrefix: 'athena-logs-bucket',
+      bucketName: `${workgroupName}-athena-logs`,
+      serverAccessLogsPrefix: `${workgroupName}-athena-logs-bucket`,
     });
 
     this.athenaWorkgroup = new CfnWorkGroup(this, 'athenaDemoWorkgroup', {
-      name: 'demo',
+      name: workgroupName,
       recursiveDeleteOption: true,
       workGroupConfiguration: {
         requesterPaysEnabled: true,

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -9,7 +9,7 @@ export { AraBucket, AraBucketProps } from './ara-bucket';
 export { Ec2SsmRole } from './ec2-ssm-role';
 export { DataLakeCatalog } from './data-lake-catalog';
 export { DataLakeExporter, DataLakeExporterProps } from './data-lake-exporter';
-export { AthenaDemoSetup } from './athena-demo-setup';
+export { AthenaDemoSetup, AthenaDemoSetupProps } from './athena-demo-setup';
 export { GlueDemoRole } from './glue-demo-role';
 export { EmrEksClusterProps, EmrEksCluster, EmrEksNodegroupOptions, EmrEksNodegroup, EmrVirtualClusterOptions, EmrManagedEndpointOptions } from './emr-eks-platform';
 export { FlywayRunner, FlywayRunnerProps } from './db-schema-manager';

--- a/core/test/e2e/athena-demo-setup.test.ts
+++ b/core/test/e2e/athena-demo-setup.test.ts
@@ -17,7 +17,8 @@ jest.setTimeout(100000);
 const integTestApp = new cdk.App();
 const stack = new cdk.Stack(integTestApp, 'AthenaDemoSetupE2eTest');
 
-const athenaSetup = new AthenaDemoSetup(stack, 'AthenaSetup');
+const athenaSetup = new AthenaDemoSetup(stack, 'AthenaSetup', {});
+const athenaSetup2 = new AthenaDemoSetup(stack, 'AthenaSetup2', {workgroupName: 'custom'});
 
 new cdk.CfnOutput(stack, 'ResultsBucketName', {
   value: athenaSetup.resultBucket.bucketName,
@@ -29,6 +30,16 @@ new cdk.CfnOutput(stack, 'AthenaWorkgroupName', {
   exportName: 'AthenaWorkgroupName',
 });
 
+new cdk.CfnOutput(stack, 'AthenaWorkgroupName2', {
+  value: athenaSetup2.athenaWorkgroup.name,
+  exportName: 'AthenaWorkgroupName2',
+});
+
+new cdk.CfnOutput(stack, 'ResultsBucketName2', {
+  value: athenaSetup2.resultBucket.bucketName,
+  exportName: 'ResultsBucketName2',
+});
+
 describe('deploy succeed', () => {
   it('can be deploy succcessfully', async () => {
     const deployResult = await deployStack(integTestApp, stack);
@@ -36,7 +47,9 @@ describe('deploy succeed', () => {
     
     // THEN
     expect(deployResult.outputs.AthenaWorkgroupName).toEqual('demo');
-    expect(deployResult.outputs.ResultsBucketName).toContain('athena-logs');
+    expect(deployResult.outputs.AthenaWorkgroupName2).toEqual('custom');
+    expect(deployResult.outputs.ResultsBucketName).toContain('demo-athena-logs');
+    expect(deployResult.outputs.ResultsBucketName2).toContain('custom-athena-logs');
 
   }, 9000000);
 });

--- a/core/test/e2e/data-domain.test.ts
+++ b/core/test/e2e/data-domain.test.ts
@@ -19,7 +19,7 @@ const stack = new cdk.Stack(integTestApp, 'DataDomainE2eTest');
 
 const domain = new DataDomain(stack, 'DataDomain', {
   domainName: 'test',
-  centralAccountId: '628862645339',
+  centralAccountId: '111111111111',
   crawlerWorkflow: true,
 });
 

--- a/core/test/unit/cdk-nag/nag-athena-demo-setup.test.ts
+++ b/core/test/unit/cdk-nag/nag-athena-demo-setup.test.ts
@@ -18,7 +18,7 @@ const mockApp = new App();
 
 const athenaDemoSetupStack = new Stack(mockApp, 'athena-demo-setup');
 // Instantiate an AthenaDemoSetup
-new AthenaDemoSetup(athenaDemoSetupStack, 'athenaDemo');
+new AthenaDemoSetup(athenaDemoSetupStack, 'athenaDemo', {});
 
 Aspects.of(athenaDemoSetupStack).add(new AwsSolutionsChecks());
 


### PR DESCRIPTION
Issue #, if available:

Description of changes: add a parameter to customize the Athena workgroup setup. The name is used for both the Athena workgroup and the S3 bucket for storing results. It allows for multiple AthenaDemoSetup to be provisioned into one single account. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.