### PR TITLE
fix: add fix for cert-manager and dep for VC

### DIFF
--- a/core/src/emr-eks-platform/emr-eks-cluster-helpers.ts
+++ b/core/src/emr-eks-platform/emr-eks-cluster-helpers.ts
@@ -35,6 +35,12 @@ export function eksClusterSetup(cluster: EmrEksCluster, scope: Construct, eksAdm
     repository: 'https://charts.jetstack.io',
     version: 'v1.10.1',
     timeout: Duration.minutes(14),
+    values: {
+      startupapicheck: {
+        timeout: '5m'
+      },
+      installCRDs: true
+    }
   });
 
   //Create service account for ALB and install ALB

--- a/core/src/emr-eks-platform/emr-eks-cluster.ts
+++ b/core/src/emr-eks-platform/emr-eks-cluster.ts
@@ -458,7 +458,7 @@ export class EmrEksCluster extends TrackedConstruct {
         metadata: { name: eksNamespace },
       })
       : null;
-
+    
     // deep clone the Role template object and replace the namespace
     const k8sRole = JSON.parse(JSON.stringify(K8sRole));
     k8sRole.metadata.namespace = eksNamespace;
@@ -487,6 +487,9 @@ export class EmrEksCluster extends TrackedConstruct {
 
     virtCluster.node.addDependency(roleBinding);
     virtCluster.node.addDependency(this.emrServiceRole);
+    
+    if (ns)
+      virtCluster.node.addDependency(ns);
 
     Tags.of(virtCluster).add('for-use-with', 'cdk-analytics-reference-architecture');
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- Add explicit dependency between the VC and the namespace to avoid race condition during delete where namespace is deleted before the VC
- Add time out the deploy of cert-manager as suggested in [here](https://github.com/cert-manager/cert-manager/issues/4646)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.