### PR TITLE
fix: remove kubctl v1.22 layer from dep

### DIFF
--- a/core/.projen/deps.json
+++ b/core/.projen/deps.json
@@ -169,10 +169,6 @@
       "type": "build"
     },
     {
-      "name": "@aws-cdk/lambda-layer-kubectl-v22",
-      "type": "bundled"
-    },
-    {
       "name": "@exodus/schemasafe",
       "type": "bundled"
     },

--- a/core/.projenrc.js
+++ b/core/.projenrc.js
@@ -87,7 +87,6 @@ const project = new awscdk.AwsCdkConstructLibrary({
     'aws-sdk',
     '@exodus/schemasafe',
     'simple-base',
-    '@aws-cdk/lambda-layer-kubectl-v22'
   ],
 
   python: {

--- a/core/package.json
+++ b/core/package.json
@@ -91,7 +91,6 @@
   "dependencies": {
     "@aws-cdk/aws-glue-alpha": "2.51.0-alpha.0",
     "@aws-cdk/aws-redshift-alpha": "2.51.0-alpha.0",
-    "@aws-cdk/lambda-layer-kubectl-v22": "^2.0.3",
     "@exodus/schemasafe": "^1.0.0-rc.9",
     "aws-sdk": "^2.1291.0",
     "js-yaml": "^3.14.1",
@@ -99,7 +98,6 @@
     "uuid": "^3.4.0"
   },
   "bundledDependencies": [
-    "@aws-cdk/lambda-layer-kubectl-v22",
     "@exodus/schemasafe",
     "aws-sdk",
     "js-yaml",


### PR DESCRIPTION
Issue #, if available:
This fix optimize the package size of the dist by removing the kubectl v1.22 lambda layer that should be important and installed by the user.

Description of changes:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.