### PR TITLE
fix: sanitize stackname for emreksimage builder

### DIFF
--- a/core/src/docker-builder/docker-build.ts
+++ b/core/src/docker-builder/docker-build.ts
@@ -6,6 +6,7 @@ import { BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
 import { AraBucket } from "../ara-bucket";
+import { Utils } from "../utils";
 import { EmrEksImageBuilderCRProviderSetup, emrOnEksImageMap } from "./docker-builder-util";
 
 
@@ -74,7 +75,7 @@ export class EmrEksImageBuilder extends Construct {
 
     super(scope, id);
 
-    this.assetBucket = AraBucket.getOrCreate(this, { bucketName: `${Stack.of(this).stackName}-ara-docker-assets`, encryption: BucketEncryption.KMS_MANAGED });
+    this.assetBucket = AraBucket.getOrCreate(this, { bucketName: `${Utils.stringSanitizer(Stack.of(this).stackName)}-ara-docker-assets`, encryption: BucketEncryption.KMS_MANAGED });
 
     let codeBuildRole = new Role(this, 'codebuildarn', {
       assumedBy: new ServicePrincipal('codebuild.amazonaws.com'),

--- a/core/test/unit/cdk-nag/nag-docker-build.test.ts
+++ b/core/test/unit/cdk-nag/nag-docker-build.test.ts
@@ -170,7 +170,7 @@ NagSuppressions.addResourceSuppressionsByPath(
 
   NagSuppressions.addResourceSuppressionsByPath(
     stack,
-    'docker-build/docker-build-ara-docker-assets/Resource',
+    'docker-build/dockerbuild-ara-docker-assets/Resource',
     [{ id: 'AwsSolutions-S1', reason: 'Log disabled the bucket hold asset needed for build no data' }],
   );
   


### PR DESCRIPTION
Issue #, if available:

Description of changes: The EmrEksImage publisher construct create an S3 bucket based on the stackname. If the stackname has capital letters the deployment will fail. This change make sure to sanitize the Stack Name before passing it as a name to S3 construct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.