### PR TITLE
fix: return roles when adding users to notebook

### DIFF
--- a/core/API.md
+++ b/core/API.md
@@ -5762,7 +5762,7 @@ Returns a string representation of this construct.
 ##### `addUser` <a name="addUser" id="aws-analytics-reference-architecture.NotebookPlatform.addUser"></a>
 
 ```typescript
-public addUser(userList: NotebookUserOptions[]): string[]
+public addUser(userList: NotebookUserOptions[]): Role[]
 ```
 
 ###### `userList`<sup>Required</sup> <a name="userList" id="aws-analytics-reference-architecture.NotebookPlatform.addUser.parameter.userList"></a>


### PR DESCRIPTION
Issue #, if available:

Description of changes: return the list of execution roles when adding a user to a notebook platform via `addUser()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.