### PR TITLE
fix: current version needs aws-cdk-lib==2.51.0

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -52,7 +52,7 @@ source .env/bin/activate
 2. Add the AWS Analytics Reference Architecture library in the dependencies of your project. Update **requirements.txt** 
 
 ```bash
-aws-cdk-lib==2.27.0
+aws-cdk-lib==2.51.0
 constructs>=10.0.0,<11.0.0
 aws_analytics_reference_architecture>=2.0.0
 ```


### PR DESCRIPTION
The current version of this demo needs aws-cdk-lib==2.51.0 otherwise will throw the following errors during installation:

```
ERROR: aws-cdk-aws-redshift-alpha 2.51.0a0 has requirement aws-cdk-lib<3.0.0,>=2.51.0, but you'll have aws-cdk-lib 2.27.0 which is incompatible.
ERROR: aws-cdk-aws-glue-alpha 2.51.0a0 has requirement aws-cdk-lib<3.0.0,>=2.51.0, but you'll have aws-cdk-lib 2.27.0 which is incompatible.
ERROR: aws-analytics-reference-architecture 2.8.4 has requirement aws-cdk-lib==2.51.0, but you'll have aws-cdk-lib 2.27.0 which is incompatible.
```