### PR TITLE
fix: update EMR on EKS job execution role permissions in the example

### DIFF
--- a/examples/emr-eks-app/README.md
+++ b/examples/emr-eks-app/README.md
@@ -15,8 +15,8 @@ This example will provision the following resources and features:
 
 ### Setup the environement
 
-The `EmrEksCluster` construct requires an IAM Role to be set as the Amazon EKS administrator.
-Edit the `lib/emr-eks-app-stack.ts` file (line 16) and add the ARN of the IAM Role you want to use as administrator.
+The `EmrEksCluster` construct can take an IAM Role as parameter to set it as the Amazon EKS administrator.
+It's optional but if you want to do this, edit the `lib/emr-eks-app-stack.ts` file (line 16) and add the ARN of the IAM Role you want to use as administrator.
 
 The code should look like this:
 

--- a/examples/emr-eks-app/lib/emr-eks-app-stack.ts
+++ b/examples/emr-eks-app/lib/emr-eks-app-stack.ts
@@ -48,6 +48,7 @@ export class EmrEksAppStack extends cdk.Stack {
           actions:['glue:*'],
           resources:[
             `arn:aws:glue:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:catalog`,
+            `arn:aws:glue:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:database/default`,
             `arn:aws:glue:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:database/emr_eks_demo`,
             `arn:aws:glue:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:table/emr_eks_demo/value_rides`,
             `arn:aws:glue:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:table/emr_eks_demo/raw_rides`

--- a/examples/emr-eks-app/lib/emr-eks-app-stack.ts
+++ b/examples/emr-eks-app/lib/emr-eks-app-stack.ts
@@ -14,8 +14,7 @@ export class EmrEksAppStack extends cdk.Stack {
     })
 
     const emrEks = ara.EmrEksCluster.getOrCreate(this,{
-      eksAdminRoleArn: '<YOUR_ADMIN_ROLE>>',
-      eksClusterName:'dataplatform',
+      eksClusterName:'emreks',
       autoscaling: ara.Autoscaler.KARPENTER,
     });
 
@@ -55,7 +54,13 @@ export class EmrEksAppStack extends cdk.Stack {
           ],
         }),
         new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW, actions:['logs:PutLogEvents','logs:CreateLogStream','logs:DescribeLogGroups','logs:DescribeLogStreams'],
+          effect: iam.Effect.ALLOW, actions:[
+            'logs:CreateLogGroup',
+            'logs:PutLogEvents',
+            'logs:CreateLogStream',
+            'logs:DescribeLogGroups',
+            'logs:DescribeLogStreams'
+          ],
           resources:['arn:aws:logs:*:*:*'],
         }),
       ]

--- a/examples/emr-eks-app/package.json
+++ b/examples/emr-eks-app/package.json
@@ -21,7 +21,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "aws-analytics-reference-architecture": "2.7.2",
+    "aws-analytics-reference-architecture": "2.8.8",
     "aws-cdk-lib": "2.51.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"


### PR DESCRIPTION
Issue #, if available:

Description of changes: fix the IAM permissions of the EMR on EKS job execution role in the EMR on EKS example. Adds CloudWatch CreateLogGroup permission

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.