### PR TITLE
fix: add k8s v1_22 layer

### DIFF
--- a/examples/emr-eks-app/lib/emr-eks-app-stack.ts
+++ b/examples/emr-eks-app/lib/emr-eks-app-stack.ts
@@ -3,6 +3,8 @@ import { Construct } from 'constructs';
 import * as ara from 'aws-analytics-reference-architecture';
 import * as iam from 'aws-cdk-lib/aws-iam' ;
 import { User } from 'aws-cdk-lib/aws-iam';
+import { KubectlV22Layer } from '@aws-cdk/lambda-layer-kubectl-v22'; 
+import { KubernetesVersion } from 'aws-cdk-lib/aws-eks';
 
 
 export class EmrEksAppStack extends cdk.Stack {
@@ -11,11 +13,15 @@ export class EmrEksAppStack extends cdk.Stack {
 
     const resultsBucket = ara.AraBucket.getOrCreate(this, {
       bucketName: 'results-bucket',
-    })
+    });
+
+    const kubectl = new KubectlV22Layer(this, 'KubectlLayer');
 
     const emrEks = ara.EmrEksCluster.getOrCreate(this,{
       eksClusterName:'emreks',
       autoscaling: ara.Autoscaler.KARPENTER,
+      kubernetesVersion: KubernetesVersion.V1_22,
+      kubectlLambdaLayer: kubectl,
     });
 
     const virtualCluster = emrEks.addEmrVirtualCluster(this,{

--- a/examples/emr-eks-app/package.json
+++ b/examples/emr-eks-app/package.json
@@ -24,6 +24,7 @@
     "aws-analytics-reference-architecture": "2.8.8",
     "aws-cdk-lib": "2.51.0",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.21"
+    "source-map-support": "^0.5.21",
+    "@aws-cdk/lambda-layer-kubectl-v22": "2.0.6"
   }
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes: This fix to the example add the k8s kubectl library part of the `package.json`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.