### PR TITLE
fix: check s3 access log permissions configuration is correct

### DIFF
--- a/core/src/ara-bucket.ts
+++ b/core/src/ara-bucket.ts
@@ -203,12 +203,16 @@ export class AraBucket extends Bucket {
 
   private constructor(scope: Construct, props: AraBucketProps) {
 
+    if(scope.node.tryGetContext('@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy') === true) {
+      throw new Error("Using @aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy is not supported please switch it to false in your cdk.json");
+    }
+
     var serverAccessLogsBucket = undefined;
     if (props.serverAccessLogsPrefix) {
       serverAccessLogsBucket = props.serverAccessLogsBucket || AraBucket.getOrCreate(scope, { 
         bucketName: 's3-access-logs', 
         encryption: BucketEncryption.S3_MANAGED,
-        objectOwnership: ObjectOwnership.OBJECT_WRITER,
+        objectOwnership: ObjectOwnership.BUCKET_OWNER_PREFERRED,
       });
     }
 

--- a/core/test/e2e/data-domain.test.ts
+++ b/core/test/e2e/data-domain.test.ts
@@ -19,7 +19,7 @@ const stack = new cdk.Stack(integTestApp, 'DataDomainE2eTest');
 
 const domain = new DataDomain(stack, 'DataDomain', {
   domainName: 'test',
-  centralAccountId: '123445678912',
+  centralAccountId: '1234567891011',
   crawlerWorkflow: true,
 });
 


### PR DESCRIPTION
Issue #, if available:

Description of changes: fix the circular dependency error when using bucket policy to manage permissions for S3 access logs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.