### PR TITLE
fix: write in batch lambda when using s3 requires table name

### DIFF
--- a/core/src/data-generator/resources/lambdas/write-in-batch/write-in-batch.py
+++ b/core/src/data-generator/resources/lambdas/write-in-batch/write-in-batch.py
@@ -268,7 +268,8 @@ def handler(event, ctx):
         adjusted_start_time = start_time + timedelta(seconds=offset)
         adjusted_end_time = end_time + timedelta(seconds=offset)
         target_params['s3'] = {'path_prefix': f'{sink_path}/ingestion_start={adjusted_start_time.isoformat()}'
-                                              f'/ingestion_end={adjusted_end_time.isoformat()}/{output_file_index:03d}'}
+                                              f'/ingestion_end={adjusted_end_time.isoformat()}/{output_file_index:03d}',
+                               'table_name': ''}
 
     # DynamoDB params
     log.info(f'ddbTableName = {event.get("ddbTableName")}')


### PR DESCRIPTION
Description of changes: Batch replay fails when using s3_params with this error:
{
  "errorMessage": "'table_name'",
  "errorType": "KeyError",
  "requestId": "5a0f8b3f-46a4-492a-a497-e5c95431a6e5",
  "stackTrace": [
    "  File \"/var/task/write-in-batch.py\", line 314, in handler\n    write_all(df_split, target_params)\n",
    "  File \"/var/task/write-in-batch.py\", line 214, in write_all\n    log.info(f\"## Writing concatenated data to the {params['table_name']} table in {target}>\")\n"
  ]
}

Adding table_name to target_params['s3'] fixes the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.