### PR TITLE
fix: upgrade ARA library version in the AWS native refarch

### DIFF
--- a/refarch/README.md
+++ b/refarch/README.md
@@ -39,6 +39,7 @@ Before starting the deployment, ensure that the following steps are completed.
     1. Python [3.8-3.9.2]
     2. Git
     3. AWS CDK: Please refer to the [Getting started](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html) guide.
+5. Disable AWS Lake Formation in the [catalog settings](https://docs.aws.amazon.com/lake-formation/latest/dg/initial-LF-setup.html#setup-change-cat-settings)
 
 #### Deployment option 1: provision stacks directly (without CI/CD pipeline)
 
@@ -78,7 +79,7 @@ If you install all modules, the Amazon QuickSight username (which can also be an
 The batch, data warehouse, data visualization, and streaming modules can be enabled/disabled using the respective context variable: `EnableBatch`/`EnableDWH`/`EnableDataviz`/`EnableStreaming`.
 To disable, for example, the data visualization module, the following argument has to be used.
    ```
-   cdk deploy  -c EnableDataviz=false ara
+   cdk deploy  -c EnableDataviz=false
    ```
    
    **NOTE:

--- a/refarch/aws-native/cdk.json
+++ b/refarch/aws-native/cdk.json
@@ -1,6 +1,7 @@
 {
   "app": "python3 app.py",
   "context": {
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": false,
     "aws-cdk:enableDiffNoFail": "true",
     "EnableBatch": "true",
     "EnableDWH": "true",

--- a/refarch/aws-native/setup.py
+++ b/refarch/aws-native/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as fp:
 
 setuptools.setup(
     name="analytics-reference-architecture",
-    version="2.9.5",
+    version="2.9.12",
 
     description="The Analytics Reference Architecture CDK app",
     long_description=long_description,
@@ -19,8 +19,8 @@ setuptools.setup(
     packages=setuptools.find_packages(where="common"),
 
     install_requires=[
-        "aws_analytics_reference_architecture==2.9.5",
-        "aws-cdk-lib>=2.51.0",
+        "aws_analytics_reference_architecture==2.9.11",
+        "aws-cdk-lib>=2.72.1",
         "aws-cdk.aws-glue-alpha>=2.26.0.a0"
         "aws-cdk.aws-redshift-alpha>=2.26.0.a0"
         "constructs>=10.0.0",


### PR DESCRIPTION
Issue #, if available:

Description of changes: upgrade ARA version to 2.9.11 in the AWS native refarch to be compatible with new S3 default configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.