### PR TITLE
feat: Add custom vpc and cidr field to emreks construct

### DIFF
--- a/core/API.md
+++ b/core/API.md
@@ -9776,10 +9776,12 @@ const emrEksClusterProps: EmrEksClusterProps = { ... }
 | <code><a href="#aws-analytics-reference-architecture.EmrEksClusterProps.property.eksAdminRoleArn">eksAdminRoleArn</a></code> | <code>string</code> | Amazon IAM Role to be added to Amazon EKS master roles that will give access to kubernetes cluster from AWS console UI. |
 | <code><a href="#aws-analytics-reference-architecture.EmrEksClusterProps.property.eksCluster">eksCluster</a></code> | <code>aws-cdk-lib.aws_eks.Cluster</code> | The EKS cluster to setup EMR on. |
 | <code><a href="#aws-analytics-reference-architecture.EmrEksClusterProps.property.eksClusterName">eksClusterName</a></code> | <code>string</code> | Name of the Amazon EKS cluster to be created. |
+| <code><a href="#aws-analytics-reference-architecture.EmrEksClusterProps.property.eksVpc">eksVpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | The VPC object where to deploy the EKS cluster VPC should have at least two private and public subnets in different Availability Zones All private subnets should have the following tags: 'for-use-with-amazon-emr-managed-policies'='true' 'kubernetes.io/role/internal-elb'='1' All public subnets should have the following tag: 'kubernetes.io/role/elb'='1' Cannot be combined with vpcCidr, if combined vpcCidr takes precendency. |
 | <code><a href="#aws-analytics-reference-architecture.EmrEksClusterProps.property.emrEksNodegroups">emrEksNodegroups</a></code> | <code><a href="#aws-analytics-reference-architecture.EmrEksNodegroup">EmrEksNodegroup</a>[]</code> | List of EmrEksNodegroup to create in the cluster in addition to the default [nodegroups]{@link EmrEksNodegroup}. |
 | <code><a href="#aws-analytics-reference-architecture.EmrEksClusterProps.property.karpenterVersion">karpenterVersion</a></code> | <code>string</code> | The version of karpenter to pass to Helm. |
 | <code><a href="#aws-analytics-reference-architecture.EmrEksClusterProps.property.kubectlLambdaLayer">kubectlLambdaLayer</a></code> | <code>aws-cdk-lib.aws_lambda.ILayerVersion</code> | Starting k8s 1.22, CDK no longer bundle the kubectl layer with the code due to breaking npm package size.  A layer needs to be passed to the Construct. |
 | <code><a href="#aws-analytics-reference-architecture.EmrEksClusterProps.property.kubernetesVersion">kubernetesVersion</a></code> | <code>aws-cdk-lib.aws_eks.KubernetesVersion</code> | Kubernetes version for Amazon EKS cluster that will be created. |
+| <code><a href="#aws-analytics-reference-architecture.EmrEksClusterProps.property.vpcCidr">vpcCidr</a></code> | <code>string</code> | The CIDR of the VPC to use with EKS, if provided a VPC with three public subnets and three private subnet is create The size of the private subnets is four time the one of the public subnet. |
 
 ---
 
@@ -9858,6 +9860,18 @@ Name of the Amazon EKS cluster to be created.
 
 ---
 
+##### `eksVpc`<sup>Optional</sup> <a name="eksVpc" id="aws-analytics-reference-architecture.EmrEksClusterProps.property.eksVpc"></a>
+
+```typescript
+public readonly eksVpc: IVpc;
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.IVpc
+
+The VPC object where to deploy the EKS cluster VPC should have at least two private and public subnets in different Availability Zones All private subnets should have the following tags: 'for-use-with-amazon-emr-managed-policies'='true' 'kubernetes.io/role/internal-elb'='1' All public subnets should have the following tag: 'kubernetes.io/role/elb'='1' Cannot be combined with vpcCidr, if combined vpcCidr takes precendency.
+
+---
+
 ##### `emrEksNodegroups`<sup>Optional</sup> <a name="emrEksNodegroups" id="aws-analytics-reference-architecture.EmrEksClusterProps.property.emrEksNodegroups"></a>
 
 ```typescript
@@ -9910,6 +9924,19 @@ public readonly kubernetesVersion: KubernetesVersion;
 - *Default:* Kubernetes v1.21 version is used
 
 Kubernetes version for Amazon EKS cluster that will be created.
+
+---
+
+##### `vpcCidr`<sup>Optional</sup> <a name="vpcCidr" id="aws-analytics-reference-architecture.EmrEksClusterProps.property.vpcCidr"></a>
+
+```typescript
+public readonly vpcCidr: string;
+```
+
+- *Type:* string
+- *Default:* A vpc with the following CIDR 10.0.0.0/16 will be used
+
+The CIDR of the VPC to use with EKS, if provided a VPC with three public subnets and three private subnet is create The size of the private subnets is four time the one of the public subnet.
 
 ---
 

--- a/core/src/emr-eks-platform/emr-eks-cluster.ts
+++ b/core/src/emr-eks-platform/emr-eks-cluster.ts
@@ -3,7 +3,7 @@
 
 import { join } from 'path';
 import { Aws, CfnOutput, CustomResource, Stack, Tags, RemovalPolicy, CfnJson, Fn } from 'aws-cdk-lib';
-import { FlowLogDestination, SubnetType } from 'aws-cdk-lib/aws-ec2';
+import { FlowLogDestination, IVpc, SubnetType } from 'aws-cdk-lib/aws-ec2';
 import {
   CapacityType,
   Cluster,
@@ -46,6 +46,7 @@ import { SingletonCfnLaunchTemplate } from '../singleton-launch-template';
 import { EmrEksNodegroupAsgTagProvider } from './emr-eks-nodegroup-asg-tag';
 import { ILayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { EmrEksJobTemplateDefinition, EmrEksJobTemplateProvider } from './emr-eks-job-template';
+import { vpcBootstrap } from './vpc-helper';
 
 /**
  * The different autoscaler available with EmrEksCluster
@@ -132,6 +133,25 @@ export interface EmrEksClusterProps {
    * @default - No layer is used
    */
   readonly kubectlLambdaLayer?: ILayerVersion;
+
+   /**
+   * The CIDR of the VPC to use with EKS, if provided a VPC with three public subnets and three private subnet is create
+   * The size of the private subnets is four time the one of the public subnet 
+   * @default - A vpc with the following CIDR 10.0.0.0/16 will be used
+   */
+   readonly vpcCidr?: string;
+
+   /**
+   * The VPC object where to deploy the EKS cluster
+   * VPC should have at least two private and public subnets in different Availability Zones
+   * All private subnets should have the following tags:
+   * 'for-use-with-amazon-emr-managed-policies'='true'
+   * 'kubernetes.io/role/internal-elb'='1'
+   * All public subnets should have the following tag:
+   * 'kubernetes.io/role/elb'='1'
+   * Cannot be combined with vpcCidr, if combined vpcCidr takes precendency
+   */
+  readonly eksVpc?: IVpc;
 }
 
 /**
@@ -266,12 +286,15 @@ export class EmrEksCluster extends TrackedConstruct {
     // create an Amazon EKS CLuster with default parameters if not provided in the properties
     if (props.eksCluster == undefined) {
 
+      let eksVpc: IVpc | undefined = props.vpcCidr ? vpcBootstrap (scope, props.vpcCidr ,this.clusterName) : props.eksVpc;
+
       this.eksCluster = new Cluster(scope, `${this.clusterName}Cluster`, {
         defaultCapacity: 0,
         clusterName: this.clusterName,
         version: props.kubernetesVersion || EmrEksCluster.DEFAULT_EKS_VERSION,
         clusterLogging: eksClusterLogging,
         kubectlLayer: props.kubectlLambdaLayer as ILayerVersion ?? undefined,
+        vpc: eksVpc
       });
 
       //Create VPC flow log for the EKS VPC

--- a/core/src/emr-eks-platform/vpc-helper.ts
+++ b/core/src/emr-eks-platform/vpc-helper.ts
@@ -1,0 +1,55 @@
+import { GatewayVpcEndpointAwsService, IpAddresses, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { Tags } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+
+/**
+ * @internal
+ * Upload podTemplates to the Amazon S3 location used by the cluster.
+ * @param {Construct} scope The local path of the yaml podTemplate files to upload
+ * @param {string} vpcCidr The cidr for vpc
+ * @param {string} eksClusterName The name used to tag the subnet and vpc
+ */
+
+export function vpcBootstrap(scope: Construct , vpcCidr: string, eksClusterName: string) : Vpc {
+
+    const vpcMask = parseInt(vpcCidr.split('/')[1]);
+
+    // Calculate subnet masks based on VPC's mask
+    const publicSubnetMask = vpcMask + 4;
+    const privateSubnetMask = publicSubnetMask + 2; // twice as large as public subnet
+
+    const vpc = new Vpc(scope, 'MyVPC', {
+      ipAddresses: IpAddresses.cidr(vpcCidr),
+      maxAzs: 3,
+      natGateways: 3,
+      subnetConfiguration: [
+        {
+          cidrMask: publicSubnetMask,
+          name: 'Public',
+          subnetType: SubnetType.PUBLIC,
+        },
+        {
+          cidrMask: privateSubnetMask,
+          name: 'Private',
+          subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+        },
+      ],
+    });
+
+    // Create a gateway endpoint for S3
+    vpc.addGatewayEndpoint('S3Endpoint', {
+      service: GatewayVpcEndpointAwsService.S3,
+    });
+
+    // Add tags to subnets
+    for (let subnet of [...vpc.publicSubnets, ...vpc.privateSubnets]) {
+      Tags.of(subnet).add('karpenter.sh/discovery', eksClusterName);
+    }
+    
+    // Add tags to vpc
+    Tags.of(vpc).add('karpenter.sh/discovery', eksClusterName);
+
+    return vpc;
+  }
+


### PR DESCRIPTION
Issue #, if available:

Description of changes: This change add the ability to control the cidr of the VPC or to provide your own VPC to deploy the EKS cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.