### PR TITLE
feat: Support EKS 1.25

### DIFF
--- a/core/.projenrc.js
+++ b/core/.projenrc.js
@@ -67,7 +67,8 @@ const project = new awscdk.AwsCdkConstructLibrary({
     '@types/prettier@2.6.0',
     `@aws-cdk/aws-redshift-alpha@${CDK_VERSION}-alpha.0`,
     `@aws-cdk/aws-glue-alpha@${CDK_VERSION}-alpha.0`,
-    '@aws-cdk/lambda-layer-kubectl-v22'
+    '@aws-cdk/lambda-layer-kubectl-v22',
+    '@aws-cdk/lambda-layer-kubectl-v25'
   ],
 
   peerDeps: [

--- a/core/src/emr-eks-platform/emr-eks-cluster.ts
+++ b/core/src/emr-eks-platform/emr-eks-cluster.ts
@@ -217,7 +217,7 @@ export class EmrEksCluster extends TrackedConstruct {
     return stack.node.tryFindChild(id) as EmrEksCluster || emrEksCluster!;
   }
   public static readonly DEFAULT_EMR_VERSION = EmrVersion.V6_8;
-  public static readonly DEFAULT_EKS_VERSION = KubernetesVersion.V1_22;
+  public static readonly DEFAULT_EKS_VERSION = KubernetesVersion.V1_25;
   public static readonly DEFAULT_CLUSTER_NAME = 'data-platform';
   public static readonly DEFAULT_KARPENTER_VERSION = 'v0.20.0';
   public readonly eksCluster: Cluster;

--- a/core/src/emr-eks-platform/resources/k8s/iam-policy-ebs-csi-driver.json
+++ b/core/src/emr-eks-platform/resources/k8s/iam-policy-ebs-csi-driver.json
@@ -1,0 +1,122 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:CreateSnapshot",
+          "ec2:AttachVolume",
+          "ec2:DetachVolume",
+          "ec2:ModifyVolume",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInstances",
+          "ec2:DescribeSnapshots",
+          "ec2:DescribeTags",
+          "ec2:DescribeVolumes",
+          "ec2:DescribeVolumesModifications"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["ec2:CreateTags"],
+        "Resource": [
+          "arn:aws:ec2:*:*:volume/*",
+          "arn:aws:ec2:*:*:snapshot/*"
+        ],
+        "Condition": {
+          "StringEquals": {
+            "ec2:CreateAction": ["CreateVolume", "CreateSnapshot"]
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["ec2:DeleteTags"],
+        "Resource": [
+          "arn:aws:ec2:*:*:volume/*",
+          "arn:aws:ec2:*:*:snapshot/*"
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["ec2:CreateVolume"],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["ec2:CreateVolume"],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "aws:RequestTag/CSIVolumeName": "*"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["ec2:CreateVolume"],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "aws:RequestTag/kubernetes.io/cluster/*": "owned"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["ec2:DeleteVolume"],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["ec2:DeleteVolume"],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "ec2:ResourceTag/CSIVolumeName": "*"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["ec2:DeleteVolume"],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "ec2:ResourceTag/kubernetes.io/cluster/*": "owned"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["ec2:DeleteSnapshot"],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["ec2:DeleteSnapshot"],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+          }
+        }
+      }
+    ]
+  }

--- a/core/test/unit/cdk-nag/nag-docker-build.test.ts
+++ b/core/test/unit/cdk-nag/nag-docker-build.test.ts
@@ -4,7 +4,7 @@
 /**
  * Tests EmrEksCluster
  *
- * @group unit/best-practice/emr-eks-image-builder
+ * @group unit/best-practice/image-builder-emr-eks
  */
 
 

--- a/core/test/unit/cdk-nag/nag-emr-eks.test.ts
+++ b/core/test/unit/cdk-nag/nag-emr-eks.test.ts
@@ -471,6 +471,15 @@ NagSuppressions.addResourceSuppressionsByPath(
   }],
 );
 
+NagSuppressions.addResourceSuppressionsByPath(
+  stack,
+  'eks-emr-studio/data-platform/IamPolicyEbsCsiDriverIAMPolicy/Resource',
+  [{
+    id: 'AwsSolutions-IAM5',
+    reason: 'Policy as defined in the CSI Driver documentation and is scoped by IRSA',
+  }],
+);
+
 test('No unsuppressed Warnings', () => {
   const warnings = Annotations.fromStack(stack).findWarning('*', Match.stringLikeRegexp('AwsSolutions-.*'));
   console.log(warnings);

--- a/core/test/unit/cdk-nag/nag-notebook-platform.test.ts
+++ b/core/test/unit/cdk-nag/nag-notebook-platform.test.ts
@@ -550,6 +550,16 @@ NagSuppressions.addResourceSuppressionsByPath(
   }],
 );
 
+
+NagSuppressions.addResourceSuppressionsByPath(
+  stack,
+  'eks-emr-studio/data-platform/IamPolicyEbsCsiDriverIAMPolicy/Resource',
+  [{
+    id: 'AwsSolutions-IAM5',
+    reason: 'Policy as defined in the CSI Driver documentation and is scoped by IRSA',
+  }],
+);
+
 test('No unsuppressed Errors', () => {
   const errors = Annotations.fromStack(stack).findError('*', Match.stringLikeRegexp('AwsSolutions-.*'));
   console.log(errors);


### PR DESCRIPTION
Issue #, if available:
This PR closes #636

Description of changes:

- Bump to EKS 1.25
- Install EBS CSI Driver
- Bump the various charts to be compatible with k8s 1.25

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.