### PR TITLE
fix: change BatchReplayer props to solve JSII conversion issue in Python with IS3Sink

### DIFF
--- a/core/API.md
+++ b/core/API.md
@@ -1594,7 +1594,7 @@ Any object.
 | <code><a href="#aws-analytics-reference-architecture.BatchReplayer.property.ddbProps">ddbProps</a></code> | <code><a href="#aws-analytics-reference-architecture.DynamoDbSink">DynamoDbSink</a></code> | Parameters to write to DynamoDB target. |
 | <code><a href="#aws-analytics-reference-architecture.BatchReplayer.property.rdsProps">rdsProps</a></code> | <code><a href="#aws-analytics-reference-architecture.DbSink">DbSink</a></code> | Parameters to write to RDS target. |
 | <code><a href="#aws-analytics-reference-architecture.BatchReplayer.property.redshiftProps">redshiftProps</a></code> | <code><a href="#aws-analytics-reference-architecture.DbSink">DbSink</a></code> | Parameters to write to Redshift target. |
-| <code><a href="#aws-analytics-reference-architecture.BatchReplayer.property.s3Props">s3Props</a></code> | <code><a href="#aws-analytics-reference-architecture.IS3Sink">IS3Sink</a></code> | Parameters to write to S3 target. |
+| <code><a href="#aws-analytics-reference-architecture.BatchReplayer.property.s3Props">s3Props</a></code> | <code><a href="#aws-analytics-reference-architecture.S3Sink">S3Sink</a></code> | Parameters to write to S3 target. |
 | <code><a href="#aws-analytics-reference-architecture.BatchReplayer.property.secGroup">secGroup</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup</code> | Security group for the WriteInBatch Lambda function. |
 | <code><a href="#aws-analytics-reference-architecture.BatchReplayer.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | VPC for the WriteInBatch Lambda function. |
 
@@ -1690,10 +1690,10 @@ Parameters to write to Redshift target.
 ##### `s3Props`<sup>Optional</sup> <a name="s3Props" id="aws-analytics-reference-architecture.BatchReplayer.property.s3Props"></a>
 
 ```typescript
-public readonly s3Props: IS3Sink;
+public readonly s3Props: S3Sink;
 ```
 
-- *Type:* <a href="#aws-analytics-reference-architecture.IS3Sink">IS3Sink</a>
+- *Type:* <a href="#aws-analytics-reference-architecture.S3Sink">S3Sink</a>
 
 Parameters to write to S3 target.
 
@@ -8731,7 +8731,7 @@ const batchReplayerProps: BatchReplayerProps = { ... }
 | <code><a href="#aws-analytics-reference-architecture.BatchReplayerProps.property.frequency">frequency</a></code> | <code>aws-cdk-lib.Duration</code> | The frequency of the replay. |
 | <code><a href="#aws-analytics-reference-architecture.BatchReplayerProps.property.rdsProps">rdsProps</a></code> | <code><a href="#aws-analytics-reference-architecture.DbSink">DbSink</a></code> | Parameters to write to RDS target. |
 | <code><a href="#aws-analytics-reference-architecture.BatchReplayerProps.property.redshiftProps">redshiftProps</a></code> | <code><a href="#aws-analytics-reference-architecture.DbSink">DbSink</a></code> | Parameters to write to Redshift target. |
-| <code><a href="#aws-analytics-reference-architecture.BatchReplayerProps.property.s3Props">s3Props</a></code> | <code><a href="#aws-analytics-reference-architecture.IS3Sink">IS3Sink</a></code> | Parameters to write to S3 target. |
+| <code><a href="#aws-analytics-reference-architecture.BatchReplayerProps.property.s3Props">s3Props</a></code> | <code><a href="#aws-analytics-reference-architecture.S3Sink">S3Sink</a></code> | Parameters to write to S3 target. |
 | <code><a href="#aws-analytics-reference-architecture.BatchReplayerProps.property.secGroup">secGroup</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup</code> | Security group for the WriteInBatch Lambda function. |
 | <code><a href="#aws-analytics-reference-architecture.BatchReplayerProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | VPC for the WriteInBatch Lambda function. |
 
@@ -8826,10 +8826,10 @@ Parameters to write to Redshift target.
 ##### `s3Props`<sup>Optional</sup> <a name="s3Props" id="aws-analytics-reference-architecture.BatchReplayerProps.property.s3Props"></a>
 
 ```typescript
-public readonly s3Props: IS3Sink;
+public readonly s3Props: S3Sink;
 ```
 
-- *Type:* <a href="#aws-analytics-reference-architecture.IS3Sink">IS3Sink</a>
+- *Type:* <a href="#aws-analytics-reference-architecture.S3Sink">S3Sink</a>
 
 Parameters to write to S3 target.
 
@@ -11209,6 +11209,66 @@ The S3 object key to grant cross account access (S3 prefix without the bucket na
 
 ---
 
+### S3Sink <a name="S3Sink" id="aws-analytics-reference-architecture.S3Sink"></a>
+
+#### Initializer <a name="Initializer" id="aws-analytics-reference-architecture.S3Sink.Initializer"></a>
+
+```typescript
+import { S3Sink } from 'aws-analytics-reference-architecture'
+
+const s3Sink: S3Sink = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#aws-analytics-reference-architecture.S3Sink.property.sinkBucket">sinkBucket</a></code> | <code>aws-cdk-lib.aws_s3.Bucket</code> | The S3 Bucket sink where the BatchReplayer writes data. |
+| <code><a href="#aws-analytics-reference-architecture.S3Sink.property.outputFileMaxSizeInBytes">outputFileMaxSizeInBytes</a></code> | <code>number</code> | The maximum file size in Bytes written by the BatchReplayer. |
+| <code><a href="#aws-analytics-reference-architecture.S3Sink.property.sinkObjectKey">sinkObjectKey</a></code> | <code>string</code> | The S3 object key sink where the BatchReplayer writes data. |
+
+---
+
+##### `sinkBucket`<sup>Required</sup> <a name="sinkBucket" id="aws-analytics-reference-architecture.S3Sink.property.sinkBucket"></a>
+
+```typescript
+public readonly sinkBucket: Bucket;
+```
+
+- *Type:* aws-cdk-lib.aws_s3.Bucket
+
+The S3 Bucket sink where the BatchReplayer writes data.
+
+:warning: **If the Bucket is encrypted with KMS, the Key must be managed by this stack.
+
+---
+
+##### `outputFileMaxSizeInBytes`<sup>Optional</sup> <a name="outputFileMaxSizeInBytes" id="aws-analytics-reference-architecture.S3Sink.property.outputFileMaxSizeInBytes"></a>
+
+```typescript
+public readonly outputFileMaxSizeInBytes: number;
+```
+
+- *Type:* number
+- *Default:* The BatchReplayer writes 100MB files maximum
+
+The maximum file size in Bytes written by the BatchReplayer.
+
+---
+
+##### `sinkObjectKey`<sup>Optional</sup> <a name="sinkObjectKey" id="aws-analytics-reference-architecture.S3Sink.property.sinkObjectKey"></a>
+
+```typescript
+public readonly sinkObjectKey: string;
+```
+
+- *Type:* string
+- *Default:* No object key is used and the BatchReplayer writes the dataset in s3://<BUCKET_NAME>/<TABLE_NAME>
+
+The S3 object key sink where the BatchReplayer writes data.
+
+---
+
 ### SynchronousAthenaQueryProps <a name="SynchronousAthenaQueryProps" id="aws-analytics-reference-architecture.SynchronousAthenaQueryProps"></a>
 
 The properties for the SynchronousAthenaQuery construct.
@@ -11943,62 +12003,6 @@ The BatchReplayer adds two columns ingestion_start and ingestion_end
 
 ---
 
-## Protocols <a name="Protocols" id="Protocols"></a>
-
-### IS3Sink <a name="IS3Sink" id="aws-analytics-reference-architecture.IS3Sink"></a>
-
-- *Implemented By:* <a href="#aws-analytics-reference-architecture.IS3Sink">IS3Sink</a>
-
-
-#### Properties <a name="Properties" id="Properties"></a>
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-| <code><a href="#aws-analytics-reference-architecture.IS3Sink.property.sinkBucket">sinkBucket</a></code> | <code>aws-cdk-lib.aws_s3.Bucket</code> | The S3 Bucket sink where the BatchReplayer writes data. |
-| <code><a href="#aws-analytics-reference-architecture.IS3Sink.property.outputFileMaxSizeInBytes">outputFileMaxSizeInBytes</a></code> | <code>number</code> | The maximum file size in Bytes written by the BatchReplayer. |
-| <code><a href="#aws-analytics-reference-architecture.IS3Sink.property.sinkObjectKey">sinkObjectKey</a></code> | <code>string</code> | The S3 object key sink where the BatchReplayer writes data. |
-
----
-
-##### `sinkBucket`<sup>Required</sup> <a name="sinkBucket" id="aws-analytics-reference-architecture.IS3Sink.property.sinkBucket"></a>
-
-```typescript
-public readonly sinkBucket: Bucket;
-```
-
-- *Type:* aws-cdk-lib.aws_s3.Bucket
-
-The S3 Bucket sink where the BatchReplayer writes data.
-
-:warning: **If the Bucket is encrypted with KMS, the Key must be managed by this stack.
-
----
-
-##### `outputFileMaxSizeInBytes`<sup>Optional</sup> <a name="outputFileMaxSizeInBytes" id="aws-analytics-reference-architecture.IS3Sink.property.outputFileMaxSizeInBytes"></a>
-
-```typescript
-public readonly outputFileMaxSizeInBytes: number;
-```
-
-- *Type:* number
-- *Default:* The BatchReplayer writes 100MB files maximum
-
-The maximum file size in Bytes written by the BatchReplayer.
-
----
-
-##### `sinkObjectKey`<sup>Optional</sup> <a name="sinkObjectKey" id="aws-analytics-reference-architecture.IS3Sink.property.sinkObjectKey"></a>
-
-```typescript
-public readonly sinkObjectKey: string;
-```
-
-- *Type:* string
-- *Default:* No object key is used and the BatchReplayer writes the dataset in s3://<BUCKET_NAME>/<TABLE_NAME>
-
-The S3 object key sink where the BatchReplayer writes data.
-
----
 
 ## Enums <a name="Enums" id="Enums"></a>
 

--- a/core/API.md
+++ b/core/API.md
@@ -1472,7 +1472,7 @@ Usage example:
 
 const myBucket = new Bucket(stack, "MyBucket")
 
-let myProps: IS3Sink = {
+let myProps: S3Sink = {
   sinkBucket: myBucket,
   sinkObjectKey: 'some-prefix',
   outputFileMaxSizeInBytes: 10000000,

--- a/core/src/data-generator/batch-replayer-helpers.ts
+++ b/core/src/data-generator/batch-replayer-helpers.ts
@@ -3,7 +3,7 @@ import { ITable } from 'aws-cdk-lib/aws-dynamodb';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 
 
-export interface IS3Sink {
+export interface S3Sink {
   /**
    * The S3 Bucket sink where the BatchReplayer writes data.
    * :warning: **If the Bucket is encrypted with KMS, the Key must be managed by this stack.
@@ -13,12 +13,12 @@ export interface IS3Sink {
    * The S3 object key sink where the BatchReplayer writes data.
    * @default - No object key is used and the BatchReplayer writes the dataset in s3://<BUCKET_NAME>/<TABLE_NAME>
    */
-  sinkObjectKey?: string;
+  readonly sinkObjectKey?: string;
   /**
    * The maximum file size in Bytes written by the BatchReplayer
    * @default - The BatchReplayer writes 100MB files maximum
    */
-  outputFileMaxSizeInBytes?: number;
+  readonly outputFileMaxSizeInBytes?: number;
 }
 
 export interface DbSink {
@@ -54,7 +54,7 @@ export interface DynamoDbSink {
  * @param dataBucketName
  * @param dataObjectKey
  */
-export function prepareS3Target(S3Props: IS3Sink, dataBucketName: string, dataObjectKey: string)
+export function prepareS3Target(S3Props: S3Sink, dataBucketName: string, dataObjectKey: string)
   : {policy:PolicyStatement; taskInputParams:Object} {
   // Add policy to allow access to bucket
   const policy = new PolicyStatement({

--- a/core/src/data-generator/batch-replayer.ts
+++ b/core/src/data-generator/batch-replayer.ts
@@ -115,7 +115,7 @@ export interface BatchReplayerProps {
  *
  * const myBucket = new Bucket(stack, "MyBucket")
  *
- * let myProps: IS3Sink = {
+ * let myProps: S3Sink = {
  *  sinkBucket: myBucket,
  *  sinkObjectKey: 'some-prefix',
  *  outputFileMaxSizeInBytes: 10000000,

--- a/core/src/data-generator/index.ts
+++ b/core/src/data-generator/index.ts
@@ -1,4 +1,4 @@
 export { BatchReplayerProps, BatchReplayer } from './batch-replayer';
-export { IS3Sink, DbSink, DynamoDbSink } from './batch-replayer-helpers';
+export { S3Sink, DbSink, DynamoDbSink } from './batch-replayer-helpers';
 export { PreparedDataset, PreparedDatasetProps } from './prepared-dataset';
 export { CustomDataset, CustomDatasetProps, CustomDatasetInputFormat } from './custom-dataset';

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -3,7 +3,7 @@
 
 export { DataLakeStorageProps, DataLakeStorage } from './data-lake-storage';
 export { SynchronousCrawlerProps, SynchronousCrawler } from './synchronous-crawler';
-export { BatchReplayerProps, BatchReplayer, PreparedDatasetProps, PreparedDataset, CustomDataset, CustomDatasetProps, CustomDatasetInputFormat, IS3Sink, DbSink, DynamoDbSink } from './data-generator';
+export { BatchReplayerProps, BatchReplayer, PreparedDatasetProps, PreparedDataset, CustomDataset, CustomDatasetProps, CustomDatasetInputFormat, S3Sink, DbSink, DynamoDbSink } from './data-generator';
 export { SynchronousAthenaQueryProps, SynchronousAthenaQuery } from './synchronous-athena-query';
 export { AraBucket, AraBucketProps } from './ara-bucket';
 export { Ec2SsmRole } from './ec2-ssm-role';

--- a/core/test/e2e/batch-replayer.test.ts
+++ b/core/test/e2e/batch-replayer.test.ts
@@ -14,7 +14,7 @@ import { Cluster } from '@aws-cdk/aws-redshift-alpha';
 import { deployStack, destroyStack } from './utils';
 
 import { BatchReplayer } from '../../src/data-generator/batch-replayer';
-import { IS3Sink, DynamoDbSink, DbSink } from '../../src/data-generator/batch-replayer-helpers';
+import { S3Sink, DynamoDbSink, DbSink } from '../../src/data-generator/batch-replayer-helpers';
 import { PreparedDataset } from '../../src/data-generator/prepared-dataset';
 import { PreBundledFunction } from '../../src/common/pre-bundled-function';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
@@ -31,7 +31,7 @@ const sinkBucket = new Bucket(stack, 'SinkBucket', {
   removalPolicy: RemovalPolicy.DESTROY,
   autoDeleteObjects: true,
 });
-let s3Props: IS3Sink = { sinkBucket: sinkBucket };
+let s3Props: S3Sink = { sinkBucket: sinkBucket };
 
 const vpc = new aws_ec2.Vpc(stack, 'Vpc');
 

--- a/core/test/unit/cdk-nag/nag-batch-replayer.test.ts
+++ b/core/test/unit/cdk-nag/nag-batch-replayer.test.ts
@@ -13,14 +13,14 @@ import { App, Aspects, Duration, Stack } from 'aws-cdk-lib';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 import { BatchReplayer, PreparedDataset } from '../../../src';
-import { IS3Sink } from '../../../lib';
+import { S3Sink } from '../../../lib';
 
 const mockApp = new App();
 
 const batchReplayerStack = new Stack(mockApp, 'BatchReplayer');
 const sinkBucket = new Bucket(batchReplayerStack, 'SinkBucket');
 // Instantiate a DataGenerator
-const s3Props: IS3Sink = { sinkBucket: sinkBucket, sinkObjectKey: 'test' };
+const s3Props: S3Sink = { sinkBucket: sinkBucket, sinkObjectKey: 'test' };
 const batchReplayer = new BatchReplayer(batchReplayerStack, 'TestBatchReplayer', {
   dataset: PreparedDataset.RETAIL_1_GB_WEB_SALE,
   frequency: Duration.seconds(120),

--- a/core/test/unit/data-generator/batch-replayer.test.ts
+++ b/core/test/unit/data-generator/batch-replayer.test.ts
@@ -18,14 +18,14 @@ import {
 
 import { Template } from 'aws-cdk-lib/assertions';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
-import { BatchReplayer, DbSink, DynamoDbSink, IS3Sink, PreparedDataset } from '../../../src';
+import { BatchReplayer, DbSink, DynamoDbSink, S3Sink, PreparedDataset } from '../../../src';
 import { IVpc, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { PreBundledFunction } from '../../../src/common/pre-bundled-function';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 
 let testStack: Stack;
-let s3Props: IS3Sink;
+let s3Props: S3Sink;
 let batchReplayer: BatchReplayer;
 let template: Template;
 let ddbProps: DynamoDbSink;
@@ -105,7 +105,7 @@ test("BatchReplayer should use default frequency", () => {
 });
 
 test("BatchReplayer should use given max output file size", () => {
-  const s3MaxOutputFileSizeSet: IS3Sink = {
+  const s3MaxOutputFileSizeSet: S3Sink = {
     sinkBucket: new Bucket(testStack, 'filesizeBucket'),
     outputFileMaxSizeInBytes: 20480,
   };
@@ -119,7 +119,7 @@ test("BatchReplayer should use given max output file size", () => {
 });
 
 test("BatchReplayer should use default max output file size 100MB", () => {
-  const s3MaxOutputFileSizeDefault: IS3Sink = {
+  const s3MaxOutputFileSizeDefault: S3Sink = {
     sinkBucket: new Bucket(testStack, 'noFilesizeBucket'),
   };
   const batchReplayerWithNoFilesizeProp = new BatchReplayer(testStack, "TestBatchReplayerWithNoFreqProp", {

--- a/core/yarn.lock
+++ b/core/yarn.lock
@@ -1083,7 +1083,7 @@
 
 "@types/js-yaml@*":
   version "4.0.5"
-  resolved "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
   integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
 
 "@types/json-schema@^7.0.9":


### PR DESCRIPTION
Issue #, if available:

Description of changes: The use of Interface with the name starting with `I` should be excluded because JSII convert it to Python Protocols and resource references cannot be used in Protocols (only values resolved at compile time). The `IS3Sink` is now a `S3Sink` which is considered as a struct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.