### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         run: cd core && npx projen build
       - name: Check for changes
         id: git_diff
-        run: git diff --exit-code || echo "::set-output name=has_changes::true"
+        run: git diff --exit-code || echo "has_changes=true" >> "$GITHUB_OUTPUT"
       - if: steps.git_diff.outputs.has_changes
         name: Commit and push changes (if changed)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         run: cd core && npx projen release
       - name: Check for new commits
         id: git_remote
-        run: echo ::set-output name=latest_commit::"$(git ls-remote origin -h ${{
+        run: echo latest_commit="$(git ls-remote origin -h ${{ >> "$GITHUB_OUTPUT"
           github.ref }} | cut -f1)"
       - name: Upload artifact
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,16 +25,15 @@ jobs:
       - name: Setup Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'zulu' # OpenJDK
-          java-version: '11'
+          distribution: "zulu" # OpenJDK
+          java-version: "11"
       - name: Install dependencies
         run: cd core && yarn install --check-files --frozen-lockfile
       - name: release
         run: cd core && npx projen release
       - name: Check for new commits
         id: git_remote
-        run: echo latest_commit="$(git ls-remote origin -h ${{ >> "$GITHUB_OUTPUT"
-          github.ref }} | cut -f1)"
+        run: echo "latest_commit=\"$(git ls-remote origin -h ${{ github.ref }} | cut -f1)\"" >> "$GITHUB_OUTPUT"
       - name: Upload artifact
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
@@ -57,7 +56,8 @@ jobs:
           name: dist
           path: core
       - name: Release
-        run: errout=$(mktemp); cd core && gh release create $(cat dist/releasetag.txt) -R
+        run:
+          errout=$(mktemp); cd core && gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
           --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode
           -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then
@@ -109,7 +109,7 @@ jobs:
       image: jsii/superchain:1-buster-slim-node16
   slack:
     name: Publish to slack channel
-    needs: 
+    needs:
       - release_npm
       - release_pypi
       - release_github

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -20,8 +20,7 @@ jobs:
         run: cd core && npx projen upgrade-dependencies
       - name: Build
         id: build
-        run: cd core && npx projen build && echo "conclusion=success" || echo >> "$GITHUB_OUTPUT"
-          "conclusion=failure" >> "$GITHUB_OUTPUT"
+        run: cd core && npx projen build && echo "conclusion=success" >> "$GITHUB_OUTPUT" || echo "conclusion=failure" >> "$GITHUB_OUTPUT"
       - name: Create Patch
         run: |-
           git add .
@@ -50,7 +49,8 @@ jobs:
           name: .upgrade.tmp.patch
           path: ${{ runner.temp }}
       - name: Apply patch
-        run: '[ -s ${{ runner.temp }}/.upgrade.tmp.patch ] && git apply ${{ runner.temp
+        run:
+          '[ -s ${{ runner.temp }}/.upgrade.tmp.patch ] && git apply ${{ runner.temp
           }}/.upgrade.tmp.patch || echo "Empty patch. Skipping."'
       - name: Create Pull Request
         id: create-pr
@@ -86,7 +86,8 @@ jobs:
             *Automatically created by projen via the "upgrade-dependencies" workflow*
       - name: Update status check
         if: steps.create-pr.outputs.pull-request-url != ''
-        run: "curl -i --fail -X POST -H \"Accept: application/vnd.github.v3+json\" -H
+        run:
+          "curl -i --fail -X POST -H \"Accept: application/vnd.github.v3+json\" -H
           \"Authorization: token ${GITHUB_TOKEN}\"
           https://api.github.com/repos/${{ github.repository }}/check-runs -d
           '{\"name\":\"build\",\"head_sha\":\"github-actions/upgrade-dependenci\

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -20,8 +20,8 @@ jobs:
         run: cd core && npx projen upgrade-dependencies
       - name: Build
         id: build
-        run: cd core && npx projen build && echo "::set-output name=conclusion::success" || echo
-          "::set-output name=conclusion::failure"
+        run: cd core && npx projen build && echo "conclusion=success" || echo >> "$GITHUB_OUTPUT"
+          "conclusion=failure" >> "$GITHUB_OUTPUT"
       - name: Create Patch
         run: |-
           git add .


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter